### PR TITLE
Fix deprecation condition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,16 @@
+.. Versioning follows semantic versioning, see also
+   https://semver.org/spec/v2.0.0.html. The most important bits are:
+   * Update the major if you break the public API
+   * Update the minor if you add new functionality
+   * Update the patch if you fixed a bug
+
+Changelog
+=========
+
+1.0.1 - 2022.05.24
+------------------
+
+**Bug fix:**
+
+- The method :meth:`is_deprecated` of :class:`~datajudge.Condition` was called despite not existing.
+

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -325,16 +325,7 @@ def merge_conditions(condition1, condition2):
         return condition2
     if condition2 is None:
         return condition1
-    if not condition1.is_deprecated() and not condition2.is_deprecated():
-        return Condition(conditions=[condition1, condition2], reduction_operator="and")
-    # At least one condition is of the deprecated fashion.
-    return Condition(
-        conditions=[
-            Condition(raw_string=str(condition1)),
-            Condition(raw_string=str(condition2)),
-        ],
-        reduction_operator="and",
-    )
+    return Condition(conditions=[condition1, condition2], reduction_operator="and")
 
 
 def get_date_span(engine, ref, date_column_name):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -799,7 +799,12 @@ def test_numeric_max_between(engine, int_table1, int_table2, data):
 
 
 @pytest.mark.parametrize(
-    "data", [(identity, 5, 15, 0.57, None), (negation, 5, 15, 0.58, None)]
+    "data",
+    [
+        (identity, 5, 15, 0.57, None),
+        (negation, 5, 15, 0.58, None),
+        (negation, 5, 15, 0.58, Condition(raw_string="col_int IS NOT NULL")),
+    ],
 )
 def test_numeric_between_within(engine, int_table1, data):
     (operation, lower_bound, upper_bound, min_fraction, condition) = data


### PR DESCRIPTION
The method `is_deprecated` no longer exists for class `Condition`.