### PR TITLE
Add: Kolmogorov-Smirnov Test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
 
 **New feature: Statistical Tests**
 
-- Implemented a new constraint :class:`~datajudge.constraints.stats.KolmogorovSmirnov2Sample` for :class:`~datajudge.BetweenRequirement` that performs a [Kolmogorov-Smirnov test](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test) between two data sources.
+- Implemented a new constraint :class:`~datajudge.constraints.stats.KolmogorovSmirnov2Sample` for :class:`~datajudge.BetweenRequirement` that performs a `Kolmogorov Smirnov Test <https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test>`_ between two data sources.
 
 1.0.1 - 2022.05.24
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,6 @@ Changelog
 
 - Implemented a new constraint :class:`~datajudge.constraints.stats.KolmogorovSmirnov2Sample` for :class:`~datajudge.BetweenRequirement` that performs a [Kolmogorov-Smirnov test](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test) between two data sources.
 
-**New method: get_column**
-
-- :meth:`db_access.get_column` allows retrieving the full data column, i.e. without applying any operations.
-
 1.0.1 - 2022.05.24
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
 
 **New feature: Statistical Tests**
 
-- Implemented a :class:`~datajudge.BetweenRequirement` constraint running a Kolmogorov Smirnov test.
+- Implemented a new constraint :class:`~datajudge.constraints.stats.KolmogorovSmirnov2Sample` for :class:`~datajudge.BetweenRequirement` that performs a [Kolmogorov-Smirnov test](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test) between two data sources.
 
 **New method: get_column**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@
 Changelog
 =========
 
+1.1.0 - 2022.06.01
+------------------
+
+**New feature: Statistical Tests**
+
+- Implemented a :class:`~datajudge.BetweenRequirement` constraint running a Kolmogorov Smirnov test.
+
+**New method: get_column**
+
+- :meth:`db_access.get_column` allows retrieving the full data column, i.e. without applying any operations.
+
 1.0.1 - 2022.05.24
 ------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pytest-html
   - make
   - numpydoc
+  - scipy
   - sphinx
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ requires-python = ">=3.8.0"
 
 dependencies = [
     "sqlalchemy >=1.4",
-    "setuptools"
+    "setuptools",
+    "scipy"
 ]
 
 [project.urls]

--- a/src/datajudge/__init__.py
+++ b/src/datajudge/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
 except Exception:
-    __version__ = "1.0.1"
+    __version__ = "1.1.0"

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -12,7 +12,7 @@ class KolmogorovSmirnov2Sample(Constraint):
     This is detected by applying the two-sample Kolmogorov-Smirnov test.
     """
 
-    def __init__(self, ref: DataReference, ref2: DataReference, significance_level: float = 0.01):
+    def __init__(self, ref: DataReference, ref2: DataReference, significance_level: float = 0.05):
         self.significance_level = significance_level
         super().__init__(ref, ref2=ref2)
 

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -11,10 +11,6 @@ from .. import db_access
 
 
 class KolmogorovSmirnov2Sample(Constraint):
-    """
-    This constraint assures that two given given data references are sampled from the same underlying distribution.
-    This is detected by applying the two-sample Kolmogorov-Smirnov test.
-    """
 
     def __init__(
         self, ref: DataReference, ref2: DataReference, significance_level: float = 0.05
@@ -49,7 +45,7 @@ class KolmogorovSmirnov2Sample(Constraint):
         result = p_value >= self.significance_level
         assertion_text = (
             f"2-Sample Kolmogorov-Smirnov between {self.ref.get_string()} and {self.target_prefix}"
-            f"has p-value {p_value}"
+            f"has p-value {p_value}  < {self.significance_level}"
             f"{self.condition_string}"
         )
 

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -11,7 +11,6 @@ from .. import db_access
 
 
 class KolmogorovSmirnov2Sample(Constraint):
-
     def __init__(
         self, ref: DataReference, ref2: DataReference, significance_level: float = 0.05
     ):
@@ -29,10 +28,6 @@ class KolmogorovSmirnov2Sample(Constraint):
 
         # calculate statistic
         statistic, p_value = ks_2samp(data, data2)
-
-        sql_query = """
-            < BIG SQL >
-        """
 
         return p_value
 
@@ -54,11 +49,3 @@ class KolmogorovSmirnov2Sample(Constraint):
         )
 
         return result, assertion_text
-
-    # test() -> get_factual + get_target
-    # get_factual -> retrieve(ref)
-    # get_target -> retrieve(ref2)
-    # test: compare(factual, target)
-
-    # get_factual -> runs sql query -> retrieves p_value
-    # get_target -> returns the TARGET p_value

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -13,7 +13,7 @@ class KolmogorovSmirnov2Sample(Constraint):
     """
 
     def __init__(self, ref: DataReference, ref2: DataReference, significance_level: float = 0.01):
-        self.significance_leve = significance_level
+        self.significance_level = significance_level
         super().__init__(ref, ref2=ref2)
 
     @staticmethod
@@ -43,14 +43,14 @@ class KolmogorovSmirnov2Sample(Constraint):
         return p_value
 
     def get_target_value(self, engine: sa.engine.Engine) -> Any:
-        return self.significance_leve
+        return self.significance_level
 
     def compare(
             self, value_factual: Any, value_target: Any
     ) -> Tuple[bool, Optional[str]]:
         # value_factual := calculated p-value from data
         # value_target := required significance level provided by user
-        result = value_factual > value_target
+        result = value_factual >= value_target
         assertion_text = (
             f"2-Sample Kolmogorov-Smirnov between {self.ref.get_string()} and {self.target_prefix}"
             f"has p-value {value_factual}"

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -3,11 +3,9 @@ from typing import Any, Optional, Tuple
 import sqlalchemy as sa
 from scipy.stats import ks_2samp
 
-from datajudge import Constraint
-from datajudge.constraints.base import OptionalSelections
-from datajudge.db_access import DataReference
-
 from .. import db_access
+from ..db_access import DataReference
+from .base import Constraint, OptionalSelections
 
 
 class KolmogorovSmirnov2Sample(Constraint):

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -48,7 +48,9 @@ class KolmogorovSmirnov2Sample(Constraint):
     def compare(
             self, value_factual: Any, value_target: Any
     ) -> Tuple[bool, Optional[str]]:
-        result = value_factual <= value_target
+        # value_factual := calculated p-value from data
+        # value_target := required significance level provided by user
+        result = value_factual > value_target
         assertion_text = (
             f"2-Sample Kolmogorov-Smirnov between {self.ref.get_string()} and {self.target_prefix}"
             f"has p-value {value_factual}"

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -30,6 +30,10 @@ class KolmogorovSmirnov2Sample(Constraint):
         # calculate statistic
         statistic, p_value = ks_2samp(data, data2)
 
+        sql_query = """
+            < BIG SQL >
+        """
+
         return p_value
 
     def retrieve(
@@ -50,3 +54,11 @@ class KolmogorovSmirnov2Sample(Constraint):
         )
 
         return result, assertion_text
+
+    # test() -> get_factual + get_target
+    # get_factual -> retrieve(ref)
+    # get_target -> retrieve(ref2)
+    # test: compare(factual, target)
+
+    # get_factual -> runs sql query -> retrieves p_value
+    # get_target -> returns the TARGET p_value

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional, Tuple
 
 import sqlalchemy as sa
-from scipy.stats import ks_2samp
 
 from .. import db_access
 from ..db_access import DataReference
@@ -21,6 +20,13 @@ class KolmogorovSmirnov2Sample(Constraint):
         For two given lists of values calculates the Kolmogorov-Smirnov test.
         Read more here: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html
         """
+        try:
+            from scipy.stats import ks_2samp
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "Calculating the Kolmogorov-Smirnov test relies on scipy."
+                "Therefore, please install scipy before using this test."
+            )
 
         # calculate statistic
         statistic, p_value = ks_2samp(data, data2)

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -35,7 +35,7 @@ class KolmogorovSmirnov2Sample(Constraint):
     def retrieve(
         self, engine: sa.engine.Engine, ref: DataReference
     ) -> Tuple[Any, OptionalSelections]:
-        return db_access.get_data(engine, ref)
+        return db_access.get_column(engine, ref)
 
     def compare(
         self, value_factual: Any, value_target: Any

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -21,8 +21,6 @@ class KolmogorovSmirnov2Sample(Constraint):
         For two given lists of values calculates the Kolmogorov-Smirnov test.
         Read more here: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html
         """
-        # data validation:
-        # TODO: perform checks that are needed for scipy's test function
 
         # calculate statistic
         statistic, p_value = ks_2samp(data, data2)

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -31,7 +31,11 @@ class KolmogorovSmirnov2Sample(Constraint):
                 "Therefore, please install scipy before using this test."
             )
 
-        # calculate statistic
+        # Currently, the calculation will be performed locally through scipy
+        # In future versions, an implementation where either the database engine
+        # (1) calculates the CDF
+        # or even (2) calculates the KS test
+        # can be expected
         statistic, p_value = ks_2samp(data, data2)
 
         return p_value
@@ -44,7 +48,7 @@ class KolmogorovSmirnov2Sample(Constraint):
     def compare(
         self, value_factual: Any, value_target: Any
     ) -> Tuple[bool, Optional[str]]:
-        # factual and target values are the corresponding columns from our data source
+
         p_value = self.calculate_2sample_ks_test(value_factual, value_target)
         result = p_value >= self.significance_level
         assertion_text = (

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,7 +1,6 @@
-from typing import Any, Optional, Tuple
+from typing import Any, Collection, Optional, Tuple
 
 import sqlalchemy as sa
-from numpy import typing
 
 from .. import db_access
 from ..db_access import DataReference
@@ -16,9 +15,7 @@ class KolmogorovSmirnov2Sample(Constraint):
         super().__init__(ref, ref2=ref2)
 
     @staticmethod
-    def calculate_2sample_ks_test(
-        data: typing.ArrayLike, data2: typing.ArrayLike
-    ) -> float:
+    def calculate_2sample_ks_test(data: Collection, data2: Collection) -> float:
         """
         For two given lists of values calculates the Kolmogorov-Smirnov test.
         Read more here: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,10 +1,13 @@
-from typing import Any, Tuple, Optional, Callable
-from .. import db_access
+from typing import Any, Optional, Tuple
+
+import sqlalchemy as sa
+from scipy.stats import ks_2samp
+
 from datajudge import Constraint
 from datajudge.constraints.base import OptionalSelections
 from datajudge.db_access import DataReference
-import sqlalchemy as sa
-from scipy.stats import ks_2samp
+
+from .. import db_access
 
 
 class KolmogorovSmirnov2Sample(Constraint):
@@ -13,7 +16,9 @@ class KolmogorovSmirnov2Sample(Constraint):
     This is detected by applying the two-sample Kolmogorov-Smirnov test.
     """
 
-    def __init__(self, ref: DataReference, ref2: DataReference, significance_level: float = 0.05):
+    def __init__(
+        self, ref: DataReference, ref2: DataReference, significance_level: float = 0.05
+    ):
         self.significance_level = significance_level
         super().__init__(ref, ref2=ref2)
 
@@ -37,7 +42,7 @@ class KolmogorovSmirnov2Sample(Constraint):
         return db_access.get_data(engine, ref)
 
     def compare(
-            self, value_factual: Any, value_target: Any
+        self, value_factual: Any, value_target: Any
     ) -> Tuple[bool, Optional[str]]:
         # factual and target values are the corresponding columns from our data source
         p_value = self.calculate_2sample_ks_test(value_factual, value_target)

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,0 +1,58 @@
+from typing import Any, Tuple, Optional, Callable
+
+from datajudge import Constraint
+from datajudge.db_access import DataReference
+import sqlalchemy as sa
+from scipy.stats import ks_2samp, kstest
+
+
+class KolmogorovSmirnov2Sample(Constraint):
+    """
+    This constraint assures that two given given data references are sampled from the same underlying distribution.
+    This is detected by applying the two-sample Kolmogorov-Smirnov test.
+    """
+
+    def __init__(self, ref: DataReference, ref2: DataReference, significance_level: float = 0.01):
+        self.significance_leve = significance_level
+        super().__init__(ref, ref2=ref2)
+
+    @staticmethod
+    def calculate_2sample_ks_test(data, data2):
+        """
+        For two given lists of values calculates the Kolmogorov-Smirnov test.
+        Read more here: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html
+        """
+        # data validation:
+        # TODO: perform checks that are needed for scipy's test function
+
+        # calculate statistic
+        statistic, p_value = ks_2samp(data, data2)
+
+        return p_value
+
+    def get_factual_value(self, engine: sa.engine.Engine) -> Any:
+        # get data
+        data = self.retrieve(engine, self.ref)
+        data2 = self.retrieve(engine, self.ref2)
+
+        # clean data
+
+        # calculate test statistics
+        p_value = self.calculate_2sample_ks_test(data, data2)
+
+        return p_value
+
+    def get_target_value(self, engine: sa.engine.Engine) -> Any:
+        return self.significance_leve
+
+    def compare(
+            self, value_factual: Any, value_target: Any
+    ) -> Tuple[bool, Optional[str]]:
+        result = value_factual <= value_target
+        assertion_text = (
+            f"2-Sample Kolmogorov-Smirnov between {self.ref.get_string()} and {self.target_prefix}"
+            f"has p-value {value_factual}"
+            f"{self.condition_string}"
+        )
+
+        return result, assertion_text

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, Tuple
 
 import sqlalchemy as sa
+from numpy import typing
 
 from .. import db_access
 from ..db_access import DataReference
@@ -15,7 +16,9 @@ class KolmogorovSmirnov2Sample(Constraint):
         super().__init__(ref, ref2=ref2)
 
     @staticmethod
-    def calculate_2sample_ks_test(data, data2):
+    def calculate_2sample_ks_test(
+        data: typing.ArrayLike, data2: typing.ArrayLike
+    ) -> float:
         """
         For two given lists of values calculates the Kolmogorov-Smirnov test.
         Read more here: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -647,9 +647,7 @@ def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Ca
 
     if not aggregate_operator:
         selection = sa.select([column])
-        result = engine.connect().execute(selection).all()
-
-        result = [elem[0] for elem in result]
+        result = engine.connect().execute(selection).scalars().all()
 
     else:
         selection = sa.select([aggregate_operator(column)])

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -640,6 +640,19 @@ def _column_aggregate(engine, ref, column_operator):
     return result, [selection]
 
 
+def _column(engine, ref):
+    subquery = ref.get_selection(engine).alias()
+    column = subquery.c[ref.get_column(engine)]
+    selection = sa.select([column])
+    result = engine.connect().execute(selection).all()
+
+    return [elem[0] for elem in result], [selection]
+
+
+def get_data(engine, ref):
+    return _column(engine, ref)
+
+
 def get_min(engine, ref):
     column_operator = sa.func.min
     return _column_aggregate(engine, ref, column_operator)

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -637,10 +637,6 @@ def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Ca
     Queries the database for the values of the relevant column (as returned by `get_column(...)`).
     If an aggregation operation is passed, the results are aggregated accordingly
     and a single scalar value is returned.
-    @param engine: SQLAlchemy engine
-    @param ref: DataReference object
-    @param aggregate_operator: Aggregation operation, e.g. SQLAlchemy's `sa.func.min`
-    @return: Scalar value if aggregate_operator is requested, otherwise list of values in column
     """
     subquery = ref.get_selection(engine).alias()
     column = subquery.c[ref.get_column(engine)]

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -6,7 +6,7 @@ import operator
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
-from typing import Callable, Sequence, final, overload, Optional
+from typing import Callable, Sequence, final, overload
 
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
@@ -632,7 +632,11 @@ def get_row_count(engine, ref, row_limit: int = None):
     return result, [selection]
 
 
-def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Optional[Callable] = None):
+def _column(
+    engine: sa.engine.Engine,
+    ref: DataReference,
+    aggregate_operator: Callable | None = None,
+):
     """
     Queries the database for the values of the relevant column (as returned by `get_column(...)`).
     If an aggregation operation is passed, the results are aggregated accordingly

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -658,7 +658,7 @@ def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Ca
     return result, [selection]
 
 
-def get_data(engine, ref):
+def get_column(engine, ref):
     return _column(engine, ref)
 
 

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -635,7 +635,8 @@ def get_row_count(engine, ref, row_limit: int = None):
 def _column(
     engine: sa.engine.Engine,
     ref: DataReference,
-    *, aggregate_operator: Callable | None = None,
+    *,
+    aggregate_operator: Callable | None = None,
 ):
     """
     Queries the database for the values of the relevant column (as returned by `get_column(...)`).

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -649,13 +649,13 @@ def _column(engine, ref, aggregate_operator: Callable = None):
         selection = sa.select([column])
         result = engine.connect().execute(selection).all()
 
-        return [elem[0] for elem in result], [selection]
+        result = [elem[0] for elem in result]
 
     else:
         selection = sa.select([aggregate_operator(column)])
         result = engine.connect().execute(selection).scalar()
 
-        return result, [selection]
+    return result, [selection]
 
 
 def get_data(engine, ref):

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -632,7 +632,7 @@ def get_row_count(engine, ref, row_limit: int = None):
     return result, [selection]
 
 
-def _column(
+def get_column(
     engine: sa.engine.Engine,
     ref: DataReference,
     *,
@@ -657,39 +657,35 @@ def _column(
     return result, [selection]
 
 
-def get_column(engine, ref):
-    return _column(engine, ref)
-
-
 def get_min(engine, ref):
     column_operator = sa.func.min
-    return _column(engine, ref, aggregate_operator=column_operator)
+    return get_column(engine, ref, aggregate_operator=column_operator)
 
 
 def get_max(engine, ref):
     column_operator = sa.func.max
-    return _column(engine, ref, aggregate_operator=column_operator)
+    return get_column(engine, ref, aggregate_operator=column_operator)
 
 
 def get_mean(engine, ref):
     def column_operator(column):
         return sa.func.avg(sa.cast(column, sa.DECIMAL))
 
-    return _column(engine, ref, aggregate_operator=column_operator)
+    return get_column(engine, ref, aggregate_operator=column_operator)
 
 
 def get_min_length(engine, ref):
     def column_operator(column):
         return sa.func.min(sa.func.length(column))
 
-    return _column(engine, ref, aggregate_operator=column_operator)
+    return get_column(engine, ref, aggregate_operator=column_operator)
 
 
 def get_max_length(engine, ref):
     def column_operator(column):
         return sa.func.max(sa.func.length(column))
 
-    return _column(engine, ref, aggregate_operator=column_operator)
+    return get_column(engine, ref, aggregate_operator=column_operator)
 
 
 def get_fraction_between(engine, ref, lower_bound, upper_bound):

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -632,7 +632,7 @@ def get_row_count(engine, ref, row_limit: int = None):
     return result, [selection]
 
 
-def _column(engine, ref, aggregate_operator: Callable = None):
+def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Callable = None):
     """
     Queries the database for the values of the relevant column (as returned by `get_column(...)`).
     If an aggregation operation is passed, the results are aggregated accordingly

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -6,7 +6,7 @@ import operator
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
-from typing import Callable, Sequence, final, overload
+from typing import Callable, Sequence, final, overload, Optional
 
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
@@ -632,7 +632,7 @@ def get_row_count(engine, ref, row_limit: int = None):
     return result, [selection]
 
 
-def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Callable = None):
+def _column(engine: sa.engine.Engine, ref: DataReference, aggregate_operator: Optional[Callable] = None):
     """
     Queries the database for the values of the relevant column (as returned by `get_column(...)`).
     If an aggregation operation is passed, the results are aggregated accordingly

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -635,7 +635,7 @@ def get_row_count(engine, ref, row_limit: int = None):
 def _column(
     engine: sa.engine.Engine,
     ref: DataReference,
-    aggregate_operator: Callable | None = None,
+    *, aggregate_operator: Callable | None = None,
 ):
     """
     Queries the database for the values of the relevant column (as returned by `get_column(...)`).

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -11,9 +11,9 @@ from .constraints import miscs as miscs_constraints
 from .constraints import nrows as nrows_constraints
 from .constraints import numeric as numeric_constraints
 from .constraints import row as row_constraints
+from .constraints import stats as statistical_constraints
 from .constraints import uniques as uniques_constraints
 from .constraints import varchar as varchar_constraints
-from .constraints import stats as statistical_constraints
 from .constraints.base import Constraint, TestResult
 from .db_access import (
     Condition,
@@ -1254,12 +1254,12 @@ class BetweenRequirement(Requirement):
         )
 
     def add_ks_2sample_constraint(
-            self,
-            column1: str,
-            column2: str,
-            condition1: Condition = None,
-            condition2: Condition = None,
-            significance_level: float = 0.05
+        self,
+        column1: str,
+        column2: str,
+        condition1: Condition = None,
+        condition2: Condition = None,
+        significance_level: float = 0.05,
     ):
         """
         Apply the so-called two-sample Kolmogorov-Smirnov test to compare the distributions of the given DataSources.
@@ -1268,5 +1268,7 @@ class BetweenRequirement(Requirement):
         ref = DataReference(self.data_source, [column1], condition=condition1)
         ref2 = DataReference(self.data_source2, [column2], condition=condition2)
         self._constraints.append(
-            statistical_constraints.KolmogorovSmirnov2Sample(ref, ref2, significance_level)
+            statistical_constraints.KolmogorovSmirnov2Sample(
+                ref, ref2, significance_level
+            )
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1253,11 +1253,20 @@ class BetweenRequirement(Requirement):
             )
         )
 
-    def add_kolmogorov_smirnov_2sample_constraint(self, significance_level: float):
+    def add_ks_2sample_constraint(
+            self,
+            column1: str,
+            column2: str,
+            condition1: Condition = None,
+            condition2: Condition = None,
+            significance_level: float = 0.05
+    ):
         """
         Apply the so-called two-sample Kolmogorov-Smirnov test to compare the distributions of the given DataSources.
         This contraint is fulfilled, when the resulting p-value of the Kolmogorov-Smirnov test is higher than the
         """
+        ref = DataReference(self.data_source, [column1], condition=condition1)
+        ref2 = DataReference(self.data_source2, [column2], condition=condition2)
         self._constraints.append(
-            statistical_constraints.KolmogorovSmirnov2Sample(self.ref, self.ref2, significance_level)
+            statistical_constraints.KolmogorovSmirnov2Sample(ref, ref2, significance_level)
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1265,7 +1265,14 @@ class BetweenRequirement(Requirement):
         Apply the so-called two-sample Kolmogorov-Smirnov test to the distributions of the two given columns.
         The constraint is fulfilled, when the resulting p-value of the test is higher than the significance level
         (default is 0.05, i.e., 5%).
+        The signifance_level must be a value between 0.0 and 1.0.
         """
+
+        if significance_level < 0.0 or significance_level > 1.0:
+            raise ValueError(
+                "The requested significance level has to be between 0.0 and 1.0. Default is 0.05."
+            )
+
         ref = DataReference(self.data_source, [column1], condition=condition1)
         ref2 = DataReference(self.data_source2, [column2], condition=condition2)
         self._constraints.append(

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1269,7 +1269,7 @@ class BetweenRequirement(Requirement):
         ref = DataReference(self.data_source, [column1], condition=condition1)
         ref2 = DataReference(self.data_source2, [column2], condition=condition2)
         self._constraints.append(
-            statistical_constraints.KolmogorovSmirnov2Sample(
+            stats_constraints.KolmogorovSmirnov2Sample(
                 ref, ref2, significance_level
             )
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -13,6 +13,7 @@ from .constraints import numeric as numeric_constraints
 from .constraints import row as row_constraints
 from .constraints import uniques as uniques_constraints
 from .constraints import varchar as varchar_constraints
+from .constraints import stats as statistical_constraints
 from .constraints.base import Constraint, TestResult
 from .db_access import (
     Condition,
@@ -1250,4 +1251,13 @@ class BetweenRequirement(Requirement):
                 comparison_columns2,
                 lambda engine: max_missing_fraction,
             )
+        )
+
+    def add_kolmogorov_smirnov_2sample_constraint(self, significance_level: float):
+        """
+        Apply the so-called two-sample Kolmogorov-Smirnov test to compare the distributions of the given DataSources.
+        This contraint is fulfilled, when the resulting p-value of the Kolmogorov-Smirnov test is higher than the
+        """
+        self._constraints.append(
+            statistical_constraints.KolmogorovSmirnov2Sample(self.ref, self.ref2, significance_level)
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -11,7 +11,7 @@ from .constraints import miscs as miscs_constraints
 from .constraints import nrows as nrows_constraints
 from .constraints import numeric as numeric_constraints
 from .constraints import row as row_constraints
-from .constraints import stats as statistical_constraints
+from .constraints import stats as stats_constraints
 from .constraints import uniques as uniques_constraints
 from .constraints import varchar as varchar_constraints
 from .constraints.base import Constraint, TestResult

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1269,7 +1269,5 @@ class BetweenRequirement(Requirement):
         ref = DataReference(self.data_source, [column1], condition=condition1)
         ref2 = DataReference(self.data_source2, [column2], condition=condition2)
         self._constraints.append(
-            stats_constraints.KolmogorovSmirnov2Sample(
-                ref, ref2, significance_level
-            )
+            stats_constraints.KolmogorovSmirnov2Sample(ref, ref2, significance_level)
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1262,8 +1262,9 @@ class BetweenRequirement(Requirement):
         significance_level: float = 0.05,
     ):
         """
-        Apply the so-called two-sample Kolmogorov-Smirnov test to compare the distributions of the given DataSources.
-        This contraint is fulfilled, when the resulting p-value of the Kolmogorov-Smirnov test is higher than the
+        Apply the so-called two-sample Kolmogorov-Smirnov test to the distributions of the two given columns.
+        The constraint is fulfilled, when the resulting p-value of the test is higher than the significance level
+        (default is 0.05 ie 5%).
         """
         ref = DataReference(self.data_source, [column1], condition=condition1)
         ref2 = DataReference(self.data_source2, [column2], condition=condition2)

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1264,7 +1264,7 @@ class BetweenRequirement(Requirement):
         """
         Apply the so-called two-sample Kolmogorov-Smirnov test to the distributions of the two given columns.
         The constraint is fulfilled, when the resulting p-value of the test is higher than the significance level
-        (default is 0.05 ie 5%).
+        (default is 0.05, i.e., 5%).
         """
         ref = DataReference(self.data_source, [column1], condition=condition1)
         ref2 = DataReference(self.data_source2, [column2], condition=condition2)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -78,6 +78,16 @@ def int_table2(engine, metadata):
 
 
 @pytest.fixture(scope="module")
+def int_square_table(engine, metadata):
+    table_name = "int_square_table"
+    engine.execute(f"DROP TABLE IF EXISTS {SCHEMA}.{table_name}")
+    columns = [sa.Column("col_int", sa.Integer())]
+    data = [{"col_int": i**2} for i in range(1, 20)]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
+@pytest.fixture(scope="module")
 def mix_table1(engine, metadata):
     table_name = "mix_table1"
     columns = [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1757,22 +1757,25 @@ def test_diff_average_between():
     return
 
 
-@pytest.mark.parametrize("data", [
-    (identity, "col_int", "col_int", None, 1.0),
-    (identity, "col_int", "col_int", Condition("col_int >= 3"), 1.0)
-])
+@pytest.mark.parametrize(
+    "data",
+    [
+        (identity, "col_int", "col_int", None, 1.0),
+        (identity, "col_int", "col_int", Condition("col_int >= 3"), 1.0),
+    ],
+)
 def test_ks_2sample_constraint_perfect_between(engine, int_table1, int_table2, data):
     """
     Test Kolmogorov-Smirnov for the same column -> p-value should be perfect 1.0.
     """
     (operation, col_1, col_2, condition, significance_level) = data
     req = requirements.BetweenRequirement.from_tables(*int_table1, *int_table1)
-    req.add_ks_2sample_constraint(column1=col_1,
-                                  column2=col_2,
-                                  condition1=condition,
-                                  condition2=condition,
-                                  significance_level=significance_level
-                                  )
+    req.add_ks_2sample_constraint(
+        column1=col_1,
+        column2=col_2,
+        condition1=condition,
+        condition2=condition,
+        significance_level=significance_level,
+    )
 
     assert operation(req[0].test(engine).outcome)
-

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1805,5 +1805,4 @@ def test_ks_2sample_constraint_wrong_between(
         column1=col_1, column2=col_2, significance_level=min_p_value
     )
 
-    # test should fail, i.e. be below the default significance level
     assert operation(req[0].test(engine).outcome)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1764,7 +1764,7 @@ def test_diff_average_between():
         (identity, "col_int", "col_int", Condition("col_int >= 3"), 1.0),
     ],
 )
-def test_ks_2sample_constraint_perfect_between(engine, int_table1, int_table2, data):
+def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
     """
     Test Kolmogorov-Smirnov for the same column -> p-value should be perfect 1.0.
     """

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1784,7 +1784,13 @@ def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
 @pytest.mark.parametrize(
     "data",
     [
-        (negation, "col_int", "col_int"),
+        (negation, "col_int", "col_int", 0.05),
+        (
+            identity,
+            "col_int",
+            "col_int",
+            0.0,
+        ),  # test should succeed although data is different
     ],
 )
 def test_ks_2sample_constraint_wrong_between(
@@ -1793,11 +1799,10 @@ def test_ks_2sample_constraint_wrong_between(
     """
     Test kolmogorov smirnov test for table and square of table -> significance level should be less than default 0.05
     """
-    (operation, col_1, col_2) = data
+    (operation, col_1, col_2, min_p_value) = data
     req = requirements.BetweenRequirement.from_tables(*int_table1, *int_square_table)
     req.add_ks_2sample_constraint(
-        column1=col_1,
-        column2=col_2,
+        column1=col_1, column2=col_2, significance_level=min_p_value
     )
 
     # test should fail, i.e. be below the default significance level

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1779,3 +1779,26 @@ def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
     )
 
     assert operation(req[0].test(engine).outcome)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        (identity, "col_int", "col_int"),
+    ],
+)
+def test_ks_2sample_constraint_wrong_between(
+    engine, int_table1, int_square_table, data
+):
+    """
+    Test kolmogorov smirnov test for table and square of table -> significance level should be less than default 0.05
+    """
+    (operation, col_1, col_2) = data
+    req = requirements.BetweenRequirement.from_tables(*int_table1, *int_square_table)
+    req.add_ks_2sample_constraint(
+        column1=col_1,
+        column2=col_2,
+    )
+
+    # test should fail, i.e. be below the default significance level
+    assert not operation(req[0].test(engine).outcome)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1784,7 +1784,7 @@ def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
 @pytest.mark.parametrize(
     "data",
     [
-        (identity, "col_int", "col_int"),
+        (negation, "col_int", "col_int"),
     ],
 )
 def test_ks_2sample_constraint_wrong_between(
@@ -1801,4 +1801,4 @@ def test_ks_2sample_constraint_wrong_between(
     )
 
     # test should fail, i.e. be below the default significance level
-    assert not operation(req[0].test(engine).outcome)
+    assert operation(req[0].test(engine).outcome)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1758,12 +1758,21 @@ def test_diff_average_between():
 
 
 @pytest.mark.parametrize("data", [
-    (identity, "col_1", "col_1", 1.0),
-    (identity, "col_1", "col_2", 0.5)
+    (identity, "col_int", "col_int", None, 1.0),
+    (identity, "col_int", "col_int", Condition("col_int >= 3"), 1.0)
 ])
-def test_kolgomorov_smirnov_2sample_between(engine, mix_table1, mix_table2, data):
-    (operation, col_1, col_2, significance_level) = data
-    req = requirements.BetweenRequirement.from_tables(*mix_table1, *mix_table2)
-    req.add_kolmogorov_smirnov_2sample_constraint(significance_level)
+def test_ks_2sample_constraint_perfect_between(engine, int_table1, int_table2, data):
+    """
+    Test Kolmogorov-Smirnov for the same column -> p-value should be perfect 1.0.
+    """
+    (operation, col_1, col_2, condition, significance_level) = data
+    req = requirements.BetweenRequirement.from_tables(*int_table1, *int_table1)
+    req.add_ks_2sample_constraint(column1=col_1,
+                                  column2=col_2,
+                                  condition1=condition,
+                                  condition2=condition,
+                                  significance_level=significance_level
+                                  )
 
     assert operation(req[0].test(engine).outcome)
+

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1755,3 +1755,15 @@ def test_groupby_aggregation_within_with_failures(
 
 def test_diff_average_between():
     return
+
+
+@pytest.mark.parametrize("data", [
+    (identity, "col_1", "col_1", 1.0),
+    (identity, "col_1", "col_2", 0.5)
+])
+def test_kolgomorov_smirnov_2sample_between(engine, mix_table1, mix_table2, data):
+    (operation, col_1, col_2, significance_level) = data
+    req = requirements.BetweenRequirement.from_tables(*mix_table1, *mix_table2)
+    req.add_kolmogorov_smirnov_2sample_constraint(significance_level)
+
+    assert operation(req[0].test(engine).outcome)


### PR DESCRIPTION
Hey!

In order to catch distributional shifts in our data-driven projects, I'd like to introduce a [Kolmogorov-Smirnov test](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test) to datajudge.

Since this introduces a new `stats.py` subpackage (and this is my first time contributing to datajudge) I'd love to hear your feedback on the following possible issues I see (hence the _draft_ status):

- [x] Afaik, this is the first test that needs the full data column from the database. Therefore, I have introduced `_column(...)` and `get_data(...)` to `db_access`. Is there a better way to do this? `_column(...)` shares a lot with `_column_aggreate(...)` of course.
- [x] Introducing `scipy` as a new dependency just for this test is a bit much. With colleagues, I have discussed options like 
    - (1) just implementing the KS test myself again 
    - (2) stating `scipy` as an optional dependency and warning the user. Any other ideas?
- [x] More tests are needed, in my opinion. Am working on that!

Thanks!