### PR TITLE
Fast Data Retrieval for Analytics Databases

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,3 +12,14 @@ or from a conda environment
 ::
 
     conda install datajudge -c conda-forge
+
+
+
+Snowflake
+^^^^
+
+If your backend is ``snowflake`` and you are querying large datasets,
+you can additionally install ``pandas`` to make use of very fast query loading
+(up to 50x speedup for large datasets).
+    Note: The ``pandas`` requirement is a bug in the snowflake-python-connector
+    and will not be needed in the future.

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - pandas
   - python>=3.8
   - pytest
   - pytest-cov

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import importlib
 import json
 import operator
 from abc import ABC, abstractmethod
@@ -13,8 +12,12 @@ import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
 
 try:
-    snowflake_available = importlib.import_module("snowflake") is not None
-    pandas_available = importlib.import_module("pandas") is not None
+    import snowflake
+
+    snowflake_available = True
+    import pandas
+
+    pandas_available = True
 except ModuleNotFoundError as err:  # ex.: 'snowflake' not found
     snowflake_available = "snowflake" not in str(err)
     pandas_available = "pandas" not in str(err)

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -654,7 +654,7 @@ def get_column(
         if is_snowflake(engine):
             snowflake_cursor: SnowflakeCursor = engine.connect().connection.cursor()
 
-            # note: this step requires pandas to be installed
+            # note: in addition to pyarrow, this currently requires pandas as well
             pa_table = snowflake_cursor.execute(str(selection)).fetch_arrow_all()
             if pa_table:  # snowflake connector returns NoneType when the table is empty
                 result = pa_table.column(0).to_numpy()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -11,7 +11,8 @@ from typing import Callable, Sequence, final, overload
 
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
-from utils import check_module_installed
+
+from .utils import check_module_installed
 
 snowflake_available = check_module_installed("snowflake")
 pandas_available = check_module_installed("pandas")

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -16,6 +16,9 @@ try:
     pandas_available = importlib.import_module("pandas") is not None
 except ModuleNotFoundError:
     pandas_available = False
+    print(
+        "For snowflake users: `pandas` is not installed, that means optimized data loading is not available."
+    )
 
 
 def is_mssql(engine: sa.engine.Engine) -> bool:
@@ -655,7 +658,7 @@ def get_column(
     if not aggregate_operator:
         selection = sa.select([column])
 
-        # snowflake-specific optimization iff pandas is installed additionally
+        # snowflake-specific optimization iff pandas is installed
         if is_snowflake(engine) and pandas_available:
             snowflake_cursor = engine.connect().connection.cursor()
 

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Callable, Sequence, final, overload
 
 import sqlalchemy as sa
-from snowflake.connector.cursor import SnowflakeCursor
 from sqlalchemy.sql.expression import FromClause
 
 
@@ -652,7 +651,7 @@ def get_column(
 
         # snowflake-specific optimization
         if is_snowflake(engine):
-            snowflake_cursor: SnowflakeCursor = engine.connect().connection.cursor()
+            snowflake_cursor = engine.connect().connection.cursor()
 
             # note: in addition to pyarrow, this currently requires pandas as well
             pa_table = snowflake_cursor.execute(str(selection)).fetch_arrow_all()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import json
 import operator
+import warnings
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
@@ -12,19 +13,24 @@ import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
 
 try:
-    import snowflake
+    import snowflake  # noqa
 
     snowflake_available = True
-    import pandas
+except ModuleNotFoundError:
+    snowflake_available = False
+
+try:
+    import pandas  # noqa
 
     pandas_available = True
-except ModuleNotFoundError as err:  # ex.: 'snowflake' not found
-    snowflake_available = "snowflake" not in str(err)
-    pandas_available = "pandas" not in str(err)
-    if snowflake_available and not pandas_available:
-        print(
-            "For snowflake users: `pandas` is not installed, that means optimized data loading is not available."
-        )
+except ModuleNotFoundError:
+    pandas_available = False
+
+
+if snowflake_available and not pandas_available:
+    warnings.warn(
+        "For snowflake users: `pandas` is not installed, that means optimized data loading is not available."
+    )
 
 
 def is_mssql(engine: sa.engine.Engine) -> bool:

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -653,7 +653,11 @@ def get_column(
             snowflake_cursor = engine.connect().connection.cursor()
 
             # note: this step requires pandas to be installed
-            result = snowflake_cursor.execute(str(selection)).fetch_pandas_all().values.ravel()
+            result = (
+                snowflake_cursor.execute(str(selection))
+                .fetch_pandas_all()
+                .values.ravel()
+            )
 
         else:
             result = engine.connect().execute(selection).scalars().all()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -11,20 +11,10 @@ from typing import Callable, Sequence, final, overload
 
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
+from utils import check_module_installed
 
-try:
-    import snowflake  # noqa
-
-    snowflake_available = True
-except ModuleNotFoundError:
-    snowflake_available = False
-
-try:
-    import pandas  # noqa
-
-    pandas_available = True
-except ModuleNotFoundError:
-    pandas_available = False
+snowflake_available = check_module_installed("snowflake")
+pandas_available = check_module_installed("pandas")
 
 
 if snowflake_available and not pandas_available:

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -13,12 +13,15 @@ import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
 
 try:
+    snowflake_available = importlib.import_module("snowflake") is not None
     pandas_available = importlib.import_module("pandas") is not None
-except ModuleNotFoundError:
-    pandas_available = False
-    print(
-        "For snowflake users: `pandas` is not installed, that means optimized data loading is not available."
-    )
+except ModuleNotFoundError as err:  # ex.: 'snowflake' not found
+    snowflake_available = "snowflake" not in str(err)
+    pandas_available = "pandas" not in str(err)
+    if snowflake_available and not pandas_available:
+        print(
+            "For snowflake users: `pandas` is not installed, that means optimized data loading is not available."
+        )
 
 
 def is_mssql(engine: sa.engine.Engine) -> bool:

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import importlib
 import json
 import operator
 from abc import ABC, abstractmethod
@@ -10,6 +11,11 @@ from typing import Callable, Sequence, final, overload
 
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import FromClause
+
+try:
+    pandas_available = importlib.import_module("pandas") is not None
+except ModuleNotFoundError:
+    pandas_available = False
 
 
 def is_mssql(engine: sa.engine.Engine) -> bool:
@@ -649,8 +655,8 @@ def get_column(
     if not aggregate_operator:
         selection = sa.select([column])
 
-        # snowflake-specific optimization
-        if is_snowflake(engine):
+        # snowflake-specific optimization iff pandas is installed additionally
+        if is_snowflake(engine) and pandas_available:
             snowflake_cursor = engine.connect().connection.cursor()
 
             # note: in addition to pyarrow, this currently requires pandas as well

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -657,6 +657,8 @@ def get_column(
             pa_table = snowflake_cursor.execute(str(selection)).fetch_arrow_all()
             if pa_table:  # snowflake connector returns NoneType when the table is empty
                 result = pa_table.column(0).to_numpy()
+            else:
+                result = []
 
         else:
             result = engine.connect().execute(selection).scalars().all()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -650,7 +650,8 @@ def get_column(
     if not aggregate_operator:
         selection = sa.select([column])
 
-        if is_snowflake(engine):  # check if we have a snowflake cursor
+        # snowflake-specific optimization
+        if is_snowflake(engine):
             snowflake_cursor: SnowflakeCursor = engine.connect().connection.cursor()
 
             # note: this step requires pandas to be installed

--- a/src/datajudge/utils.py
+++ b/src/datajudge/utils.py
@@ -1,0 +1,8 @@
+def check_module_installed(module_name: str) -> bool:
+    import importlib
+
+    try:
+        mod = importlib.import_module(module_name)
+        return mod is not None
+    except ModuleNotFoundError:
+        return False

--- a/src/datajudge/utils.py
+++ b/src/datajudge/utils.py
@@ -2,7 +2,7 @@ def check_module_installed(module_name: str) -> bool:
     import importlib
 
     try:
-        mod = importlib.import_module(module_name)
-        return mod is not None
+        importlib.import_module(module_name)
+        return True
     except ModuleNotFoundError:
         return False


### PR DESCRIPTION
Hey there, 

after introducing a statistical test with #23, I now want to integrate a way to load a large batch of data (`> 100,000,000`) within a reasonable amount of time and memory use.

For this, snowflake's sqlalchemy connector already provides a convenient method that works surprisingly well. You can read more about it [here](https://docs.snowflake.com/en/user-guide/python-connector-api.html#fetch_pandas_all).

Since I dislike or am unsure about some changes here, this will be a draft first. Concretely speaking, the following things are unclear now:

- [x] Is there a way to _not_ use pandas as an intermediate representation? (Additional dependency, data needs to be transformed, etc.)
- [x] Can we only do this for snowflake, or do we have similar methods for other database systems as well?