### PR TITLE
Implement Kolmogorov Smirnov Test in SQL-only

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+1.1.1 - 2022.06.30
+------------------
+
+**New: SQL implementation for KS-test**
+
+- The Kolgomorov Smirnov test is now implemented in pure SQL, shifting the computation to the database engine, improving performance tremendously.
+
 1.1.0 - 2022.06.01
 ------------------
 

--- a/src/datajudge/constraints/base.py
+++ b/src/datajudge/constraints/base.py
@@ -29,6 +29,7 @@ class TestResult:
     constraint_description: Optional[str] = field(default=None, repr=False)
     _factual_queries: Optional[str] = field(default=None, repr=False)
     _target_queries: Optional[str] = field(default=None, repr=False)
+    result_values: Optional[dict] = field(default=None, repr=False)
 
     @property
     def logging_message(self):
@@ -63,8 +64,8 @@ class TestResult:
         )
 
     @classmethod
-    def success(cls):
-        return cls(True)
+    def success(cls, **kwargs):
+        return cls(True, **kwargs)
 
     @classmethod
     def failure(cls, *args, **kwargs):

--- a/src/datajudge/constraints/base.py
+++ b/src/datajudge/constraints/base.py
@@ -29,7 +29,6 @@ class TestResult:
     constraint_description: Optional[str] = field(default=None, repr=False)
     _factual_queries: Optional[str] = field(default=None, repr=False)
     _target_queries: Optional[str] = field(default=None, repr=False)
-    result_values: Optional[dict] = field(default=None, repr=False)
 
     @property
     def logging_message(self):
@@ -64,8 +63,8 @@ class TestResult:
         )
 
     @classmethod
-    def success(cls, **kwargs):
-        return cls(True, **kwargs)
+    def success(cls):
+        return cls(True)
 
     @classmethod
     def failure(cls, *args, **kwargs):

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,6 +1,6 @@
 import math
 import warnings
-from typing import Optional
+from typing import Optional, Union
 
 import sqlalchemy as sa
 from sqlalchemy.sql import Selectable
@@ -69,8 +69,8 @@ class KolmogorovSmirnov2Sample(Constraint):
     @staticmethod
     def calculate_statistic(
         engine,
-        table1_def: tuple[Selectable | str, str],
-        table2_def: tuple[Selectable | str, str],
+        table1_def: tuple[Union[Selectable, str], str],
+        table2_def: tuple[Union[Selectable, str], str],
     ) -> tuple[float, Optional[float], int, int]:
 
         # retrieve test statistic d, as well as sample sizes m and n

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -40,8 +40,15 @@ class KolmogorovSmirnov2Sample(Constraint):
             )
             return None
 
-        d_alpha = d * math.sqrt(samples)
-        approx_p = 2 * math.exp(-(d_alpha**2))
+        try:
+            from scipy.stats.distributions import kstwo
+
+            approx_p = kstwo.sf(
+                d, round((n_samples * m_samples) / (n_samples + m_samples))
+            )
+        except ModuleNotFoundError:
+            d_alpha = d * math.sqrt(samples)
+            approx_p = 2 * math.exp(-(d_alpha**2))
 
         # clamp value to [0, 1]
         return 1.0 if approx_p > 1.0 else 0.0 if approx_p < 0.0 else approx_p

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -30,7 +30,7 @@ class KolmogorovSmirnov2Sample(Constraint):
         'A procedure to find exact critical values of Kolmogorov-Smirnov Test', Silvia Fachinetti, 2009
         """
 
-        n = max(m, n) // min(m, n)
+        n = m + n // 2
         if n < 35:
             warnings.warn(
                 "Approximating the p-value is not accurate enough for sample size < 35"
@@ -38,11 +38,16 @@ class KolmogorovSmirnov2Sample(Constraint):
             return None
 
         d_alpha = d * math.sqrt(n)
-        return -2 * math.exp(-(d_alpha**2))
+        approx_p = 2 * math.exp(-(d_alpha**2))
+
+        # clamp value to [0, 1]
+        return 1.0 if approx_p > 1.0 else 0.0 if approx_p < 0.0 else approx_p
 
     @staticmethod
     def check_acceptance(d: float, n: int, m: int, accepted_level):
         def c(alpha: float):
+            if alpha == 0.0:
+                return alpha + 1e-10
             return math.sqrt(-math.log(alpha / 2.0) * 0.5)
 
         # source: https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -67,11 +67,9 @@ class KolmogorovSmirnov2Sample(Constraint):
     def test(self, engine: sa.engine.Engine) -> TestResult:
 
         # get query selections and column names for target columns
-        selection1 = (
-            self.ref.data_source.table_name  # type: ignore
-        )  # TODO: this will fail for RawQueryDataSource objects.
+        selection1 = str(self.ref.data_source.get_clause(engine))
         column1 = self.ref.get_column(engine)
-        selection2 = self.ref2.data_source.table_name  # mypy: ignore-errors
+        selection2 = str(self.ref2.data_source.get_clause(engine))
         column2 = self.ref2.get_column(engine)
 
         # retrieve test statistic d, as well as sample sizes m and n

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -56,9 +56,11 @@ class KolmogorovSmirnov2Sample(Constraint):
     def test(self, engine: sa.engine.Engine) -> TestResult:
 
         # get query selections and column names for target columns
-        selection1 = self.ref.get_selection(engine)
+        selection1 = (
+            self.ref.data_source.table_name  # type: ignore
+        )  # TODO: this will fail for RawQueryDataSource objects.
         column1 = self.ref.get_column(engine)
-        selection2 = self.ref2.get_selection(engine)
+        selection2 = self.ref2.data_source.table_name  # mypy: ignore-errors
         column2 = self.ref2.get_column(engine)
 
         # retrieve test statistic d, as well as sample sizes m and n

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -47,7 +47,7 @@ class KolmogorovSmirnov2Sample(Constraint):
     def check_acceptance(d: float, n: int, m: int, accepted_level):
         def c(alpha: float):
             if alpha == 0.0:
-                return alpha + 1e-10
+                alpha = alpha + 1e-10
             return math.sqrt(-math.log(alpha / 2.0) * 0.5)
 
         # source: https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,6 +1,6 @@
 import math
 import warnings
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import sqlalchemy as sa
 from sqlalchemy.sql import Selectable
@@ -69,9 +69,9 @@ class KolmogorovSmirnov2Sample(Constraint):
     @staticmethod
     def calculate_statistic(
         engine,
-        table1_def: tuple[Union[Selectable, str], str],
-        table2_def: tuple[Union[Selectable, str], str],
-    ) -> tuple[float, Optional[float], int, int]:
+        table1_def: Tuple[Union[Selectable, str], str],
+        table2_def: Tuple[Union[Selectable, str], str],
+    ) -> Tuple[float, Optional[float], int, int]:
 
         # retrieve test statistic d, as well as sample sizes m and n
         d_statistic, n_samples, m_samples = db_access.get_ks_2sample(

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -91,7 +91,9 @@ class KolmogorovSmirnov2Sample(Constraint):
         if p_value:
             assertion_text += f"\n p-value: {p_value}"
 
+        # store values s.t. they can be checked later
+        result_values = {"d_statistic": d_statistic, "p_value": p_value}
         if not result:
-            return TestResult.failure(assertion_text)
+            return TestResult.failure(assertion_text, result_values=result_values)
 
-        return TestResult.success()
+        return TestResult.success(result_values=result_values)

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -46,9 +46,7 @@ class KolmogorovSmirnov2Sample(Constraint):
     @staticmethod
     def check_acceptance(d: float, n: int, m: int, accepted_level):
         def c(alpha: float):
-            if alpha == 0.0:
-                alpha = alpha + 1e-10
-            return math.sqrt(-math.log(alpha / 2.0) * 0.5)
+            return math.sqrt(-math.log(alpha / 2.0 + 1e-10) * 0.5)
 
         # source: https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test
         return d <= c(accepted_level) * math.sqrt((n + m) / (n * m))

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -92,8 +92,7 @@ class KolmogorovSmirnov2Sample(Constraint):
             assertion_text += f"\n p-value: {p_value}"
 
         # store values s.t. they can be checked later
-        result_values = {"d_statistic": d_statistic, "p_value": p_value}
         if not result:
-            return TestResult.failure(assertion_text, result_values=result_values)
+            return TestResult.failure(assertion_text)
 
-        return TestResult.success(result_values=result_values)
+        return TestResult.success()

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,8 +1,9 @@
 import math
 import warnings
-from typing import Any, Optional
+from typing import Optional
 
 import sqlalchemy as sa
+from sqlalchemy.sql import Selectable
 
 from .. import db_access
 from ..db_access import DataReference
@@ -33,6 +34,7 @@ class KolmogorovSmirnov2Sample(Constraint):
             )
             return None
 
+        # if scipy is installed, accurately calculate the p_value using the full distribution
         try:
             from scipy.stats.distributions import kstwo
 
@@ -65,7 +67,11 @@ class KolmogorovSmirnov2Sample(Constraint):
         )
 
     @staticmethod
-    def calculate_statistic(engine, table1_def: tuple, table2_def: tuple) -> Any:
+    def calculate_statistic(
+        engine,
+        table1_def: tuple[Selectable | str, str],
+        table2_def: tuple[Selectable | str, str],
+    ) -> tuple[float, Optional[float], int, int]:
 
         # retrieve test statistic d, as well as sample sizes m and n
         d_statistic, n_samples, m_samples = db_access.get_ks_2sample(

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,6 +1,6 @@
 import math
 import warnings
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import sqlalchemy as sa
 
@@ -24,7 +24,7 @@ class KolmogorovSmirnov2Sample(Constraint):
         return sel, col
 
     @staticmethod
-    def approximate_p_value(d: float, m: int, n: int) -> float | None:
+    def approximate_p_value(d: float, m: int, n: int) -> Optional[float]:
         """
         Calculates the approximate p-value according to
         'A procedure to find exact critical values of Kolmogorov-Smirnov Test', Silvia Fachinetti, 2009

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -24,6 +24,8 @@ class KolmogorovSmirnov2Sample(Constraint):
         """
         Calculates the approximate p-value according to
         'A procedure to find exact critical values of Kolmogorov-Smirnov Test', Silvia Fachinetti, 2009
+
+        Note: For environments with `scipy` installed, this method will return a quasi-exact p-value.
         """
 
         # approximation does not work for small sample sizes

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -947,8 +947,8 @@ SELECT MAX(ABS(cdf1 - cdf2))
 FROM replaced_nulls; -- Step 5: Calculate final statistic
     """
 
-    d_statisitic = engine.execute(ks_query_string).scalar()
+    d_statistic = engine.execute(ks_query_string).scalar()
     n = engine.execute(f"SELECT COUNT(*) FROM ({table1_selection}) as n_table").scalar()
     m = engine.execute(f"SELECT COUNT(*) FROM ({table2_selection}) as m_table").scalar()
 
-    return d_statisitic, n, m
+    return d_statistic, n, m

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -908,16 +908,14 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     """
     Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
     """
-    table1_selection, col1 = table1
-    table2_selection, col2 = table2
 
-    if is_mssql(engine):
-        table1_selection = str(table1_selection).replace(
-            '"', ""
-        )  # tempdb.dbo.int_table
-        table2_selection = str(table2_selection).replace(
-            '"', ""
-        )  # "tempdb.dbo".int_table
+    # make sure we have a string representation here
+    table1_selection, col1 = str(table1[0]), str(table1[1])
+    table2_selection, col2 = str(table2[0]), str(table2[1])
+
+    if is_mssql(engine):  # "tempdb.dbo".table_name -> tempdb.dbo.table_name
+        table1_selection = table1_selection.replace('"', "")
+        table2_selection = table2_selection.replace('"', "")
 
     # for RawQueryDataSource this could be a whole subquery and will therefore need to be wrapped
     if "SELECT" in table1_selection:

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -902,3 +902,50 @@ def get_column_array_agg(
             for t in result
         ]
     return result, selections
+
+
+def get_ks_2sample(engine: sa.engine.Engine, ref: DataReference, ref2: DataReference):
+    """
+    Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
+    """
+
+    tab1, col1 = None, None
+    tab2, col2 = None, None
+
+    ks_query_string = f"""
+        WITH cdf_unfilled AS (
+            -- Step 1: Calculate the CDF for both tables and join them together
+            SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
+            FROM
+            (
+                SELECT val, MAX(cdf) as cdf FROM (
+                    SELECT val, cume_dist() over (order by val) as cdf
+                    FROM (SELECT {col1} as val FROM {tab1}) -- Change TABLE and COL here
+                    ORDER BY val
+                ) GROUP BY val
+            ) as tab1
+            FULL OUTER JOIN
+            (
+                SELECT val, MAX(cdf) as cdf FROM (
+                    SELECT val, cume_dist() over (order by val) as cdf
+                    FROM (SELECT {col2} as val FROM {tab2}) -- Change TABLE and COL here
+                    ORDER BY val
+                ) GROUP BY val
+            ) as tab2
+            ON tab1.val = tab2.val
+            ORDER BY v
+        ), grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
+            SELECT v,
+                COUNT(cdf1) over (order by v) as _grp1, cdf1,
+                COUNT(cdf2) over (order by v) as _grp2, cdf2
+            FROM cdf_unfilled
+        ), filled_cdf AS ( -- Step 3: Select first non-null value per group (defined by grouper)
+            SELECT v, first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
+                    first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
+        FROM grouped_table
+        ) SELECT * FROM filled_cdf;
+    """
+
+    d_statisitic = engine.execute(ks_query_string).scalar()
+
+    return d_statisitic

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -912,40 +912,43 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     table2_selection, col2 = table2
 
     ks_query_string = f"""
-        WITH tab1 AS (
-            SELECT val, MAX(cdf) as cdf FROM (
-                SELECT val, cume_dist() over (order by val) as cdf
-                FROM (SELECT {col1} as val FROM ({table1_selection})) -- Change TABLE and COL here
-                ORDER BY val
-            ) GROUP BY val
-        ), tab2 AS (
-            SELECT val, MAX(cdf) as cdf FROM (
-                SELECT val, cume_dist() over (order by val) as cdf
-                FROM (SELECT {col2} as val FROM ({table2_selection})) -- Change TABLE and COL here
-                ORDER BY val
-            ) GROUP BY val
-        ), cdf_unfilled AS (
-        SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
-        FROM tab1 FULL OUTER JOIN tab2 ON tab1.val = tab2.val
-        ORDER BY v
-        ), grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
-            SELECT v,
-                COUNT(cdf1) over (order by v) as _grp1, cdf1,
-                COUNT(cdf2) over (order by v) as _grp2, cdf2
-            FROM cdf_unfilled
-        ), filled_cdf AS ( -- Step 3: Select first non-null value per group (defined by grouper)
-            SELECT v, first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
-                    first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
-            FROM grouped_table
-        ), replaced_nulls AS ( -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
-        SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
-        FROM filled_cdf
-        )
-        SELECT MAX(ABS(cdf1-cdf2)) FROM replaced_nulls; -- Step 5: Calculate final statistic
+WITH tab1 AS (SELECT val, MAX(cdf) as cdf
+              FROM (SELECT val, cume_dist() over (order by val) as cdf
+                    FROM (SELECT {col1} as val
+                          FROM ({table1_selection}) as temp01) as temp03 -- Change TABLE and COL here
+                    ORDER BY val) as temp05
+              GROUP BY val),
+     tab2 AS (SELECT val, MAX(cdf) as cdf
+              FROM (SELECT val, cume_dist() over (order by val) as cdf
+                    FROM (SELECT {col2} as val
+                          FROM ({table2_selection}) as temp02) as temp04 -- Change TABLE and COL here
+                    ORDER BY val) as temp06
+              GROUP BY val),
+     cdf_unfilled AS (SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
+                      FROM tab1
+                               FULL OUTER JOIN tab2 ON tab1.val = tab2.val
+                      ORDER BY v),
+     grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
+         SELECT v,
+                COUNT(cdf1) over (order by v) as _grp1,
+                cdf1,
+                COUNT(cdf2) over (order by v) as _grp2,
+                cdf2
+         FROM cdf_unfilled),
+     filled_cdf AS ( -- Step 3: Select first non-null value per group (defined by grouper)
+         SELECT v,
+                first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
+                first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
+         FROM grouped_table),
+     replaced_nulls AS ( -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
+         SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
+         FROM filled_cdf)
+SELECT MAX(ABS(cdf1 - cdf2))
+FROM replaced_nulls; -- Step 5: Calculate final statistic
     """
 
     d_statisitic = engine.execute(ks_query_string).scalar()
-    n = engine.execute(f"SELECT COUNT(*) FROM ({table1_selection})").scalar()
-    m = engine.execute(f"SELECT COUNT(*) FROM ({table2_selection})").scalar()
+    n = engine.execute(f"SELECT COUNT(*) FROM ({table1_selection}) as n_table").scalar()
+    m = engine.execute(f"SELECT COUNT(*) FROM ({table2_selection}) as m_table").scalar()
 
     return d_statisitic, n, m

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -904,7 +904,9 @@ def get_column_array_agg(
     return result, selections
 
 
-def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
+def get_ks_2sample(
+    engine: sa.engine.Engine, table1: tuple, table2: tuple
+) -> tuple[float, int, int]:
     """
     Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
     """
@@ -978,7 +980,11 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     """
 
     d_statistic = engine.execute(ks_query_string).scalar()
-    n = engine.execute(f"SELECT COUNT(*) FROM {table1_selection} as n_table").scalar()
-    m = engine.execute(f"SELECT COUNT(*) FROM {table2_selection} as m_table").scalar()
+    n_samples = engine.execute(
+        f"SELECT COUNT(*) FROM {table1_selection} as n_table"
+    ).scalar()
+    m_samples = engine.execute(
+        f"SELECT COUNT(*) FROM {table2_selection} as m_table"
+    ).scalar()
 
-    return d_statistic, n, m
+    return d_statistic, n_samples, m_samples

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -913,17 +913,17 @@ def get_ks_2sample(engine: sa.engine.Engine, ref: DataReference, ref2: DataRefer
     tab2, col2 = str(ref2.get_selection(engine)), ref2.get_column(engine)
     ks_query_string = f"""
         WITH tab1 AS (
-        SELECT val, MAX(cdf) as cdf FROM (
-            SELECT val, cume_dist() over (order by val) as cdf
-            FROM (SELECT {col1} as val FROM ({tab1})) -- Change TABLE and COL here
-            ORDER BY val
-        ) GROUP BY val
+            SELECT val, MAX(cdf) as cdf FROM (
+                SELECT val, cume_dist() over (order by val) as cdf
+                FROM (SELECT {col1} as val FROM ({tab1})) -- Change TABLE and COL here
+                ORDER BY val
+            ) GROUP BY val
         ), tab2 AS (
-        SELECT val, MAX(cdf) as cdf FROM (
-            SELECT val, cume_dist() over (order by val) as cdf
-            FROM (SELECT {col2} as val FROM ({tab2})) -- Change TABLE and COL here
-            ORDER BY val
-        ) GROUP BY val
+            SELECT val, MAX(cdf) as cdf FROM (
+                SELECT val, cume_dist() over (order by val) as cdf
+                FROM (SELECT {col2} as val FROM ({tab2})) -- Change TABLE and COL here
+                ORDER BY val
+            ) GROUP BY val
         ), cdf_unfilled AS (
         SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
         FROM tab1 FULL OUTER JOIN tab2 ON tab1.val = tab2.val

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -916,18 +916,21 @@ WITH tab1 AS (SELECT val, MAX(cdf) as cdf
               FROM (SELECT val, cume_dist() over (order by val) as cdf
                     FROM (SELECT {col1} as val
                           FROM ({table1_selection}) as temp01) as temp03 -- Change TABLE and COL here
-                    ORDER BY val) as temp05
+                    -- ORDER BY val -- removed, because invalid in MS-SQL Server
+                    ) as temp05
               GROUP BY val),
      tab2 AS (SELECT val, MAX(cdf) as cdf
               FROM (SELECT val, cume_dist() over (order by val) as cdf
                     FROM (SELECT {col2} as val
                           FROM ({table2_selection}) as temp02) as temp04 -- Change TABLE and COL here
-                    ORDER BY val) as temp06
+                    -- ORDER BY val -- removed, because invalid in MS-SQL Server
+                    ) as temp06
               GROUP BY val),
      cdf_unfilled AS (SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
                       FROM tab1
                                FULL OUTER JOIN tab2 ON tab1.val = tab2.val
-                      ORDER BY v),
+                      -- ORDER BY v -- removed, because invalid in MS-SQL Server
+                      ),
      grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
          SELECT v,
                 COUNT(cdf1) over (order by v) as _grp1,

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -923,43 +923,51 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
         table1_selection = f"({table1_selection})"
         table2_selection = f"({table2_selection})"
 
+    # for a more extensive explanation, see:
+    # https://github.com/Quantco/datajudge/pull/28#issuecomment-1165587929
     ks_query_string = f"""
-        WITH tab1 AS (SELECT val, MAX(cdf) as cdf
-                      FROM (SELECT val, cume_dist() over (order by val) as cdf
-                            FROM (SELECT {col1} as val
-                                  FROM {table1_selection} as temp01) as temp03 -- Change TABLE and COL here
-                            -- ORDER BY val -- removed, because invalid in MS-SQL Server
-                            ) as temp05
-                      GROUP BY val),
-             tab2 AS (SELECT val, MAX(cdf) as cdf
-                      FROM (SELECT val, cume_dist() over (order by val) as cdf
-                            FROM (SELECT {col2} as val
-                                  FROM {table2_selection} as temp02) as temp04 -- Change TABLE and COL here
-                            -- ORDER BY val -- removed, because invalid in MS-SQL Server
-                            ) as temp06
-                      GROUP BY val),
-             cdf_unfilled AS (SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
-                              FROM tab1
-                                       FULL OUTER JOIN tab2 ON tab1.val = tab2.val
-                              -- ORDER BY v -- removed, because invalid in MS-SQL Server
-                              ),
-             grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
-                 SELECT v,
-                        COUNT(cdf1) over (order by v) as _grp1,
-                        cdf1,
-                        COUNT(cdf2) over (order by v) as _grp2,
-                        cdf2
-                 FROM cdf_unfilled),
-             filled_cdf AS ( -- Step 3: Select first non-null value per group (defined by grouper)
-                 SELECT v,
-                        first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
-                        first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
-                 FROM grouped_table),
-             replaced_nulls AS ( -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
-                 SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
-                 FROM filled_cdf)
-        SELECT MAX(ABS(cdf1 - cdf2))
-        FROM replaced_nulls; -- Step 5: Calculate final statistic
+        WITH
+        tab1 AS (
+            SELECT val, MAX(cdf) as cdf
+            FROM (SELECT val, cume_dist() over (order by val) as cdf
+                FROM (SELECT {col1} as val
+                      FROM {table1_selection} as temp01) as temp03 -- Change TABLE and COL here
+                ) as temp05
+            GROUP BY val
+        ),
+        tab2 AS (
+            SELECT val, MAX(cdf) as cdf
+            FROM (SELECT val, cume_dist() over (order by val) as cdf
+                FROM (SELECT {col2} as val
+                      FROM {table2_selection} as temp02) as temp04 -- Change TABLE and COL here
+                ) as temp06
+            GROUP BY val
+        ),
+        cdf_unfilled AS (
+            SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
+            FROM tab1 FULL OUTER JOIN tab2 ON tab1.val = tab2.val
+        ),
+        -- Step 2: Create a grouper attribute to fill values forward
+        grouped_table AS (
+            SELECT v,
+                COUNT(cdf1) over (order by v) as _grp1,
+                cdf1,
+                COUNT(cdf2) over (order by v) as _grp2,
+                cdf2
+            FROM cdf_unfilled
+        ),
+        -- Step 3: Select first non-null value per group (defined by grouper)
+        filled_cdf AS (
+            SELECT v,
+                first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
+                first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
+            FROM grouped_table),
+        -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
+        replaced_nulls AS (
+            SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
+            FROM filled_cdf)
+        -- Step 5: Calculate final statistic as max. distance
+        SELECT MAX(ABS(cdf1 - cdf2)) FROM replaced_nulls;
     """
 
     d_statistic = engine.execute(ks_query_string).scalar()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -904,24 +904,24 @@ def get_column_array_agg(
     return result, selections
 
 
-def get_ks_2sample(engine: sa.engine.Engine, ref: DataReference, ref2: DataReference):
+def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     """
     Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
     """
+    table1_selection, col1 = table1
+    table2_selection, col2 = table2
 
-    tab1, col1 = str(ref.get_selection(engine)), ref.get_column(engine)
-    tab2, col2 = str(ref2.get_selection(engine)), ref2.get_column(engine)
     ks_query_string = f"""
         WITH tab1 AS (
             SELECT val, MAX(cdf) as cdf FROM (
                 SELECT val, cume_dist() over (order by val) as cdf
-                FROM (SELECT {col1} as val FROM ({tab1})) -- Change TABLE and COL here
+                FROM (SELECT {col1} as val FROM ({table1_selection})) -- Change TABLE and COL here
                 ORDER BY val
             ) GROUP BY val
         ), tab2 AS (
             SELECT val, MAX(cdf) as cdf FROM (
                 SELECT val, cume_dist() over (order by val) as cdf
-                FROM (SELECT {col2} as val FROM ({tab2})) -- Change TABLE and COL here
+                FROM (SELECT {col2} as val FROM ({table2_selection})) -- Change TABLE and COL here
                 ORDER BY val
             ) GROUP BY val
         ), cdf_unfilled AS (

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -919,6 +919,7 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
             '"', ""
         )  # "tempdb.dbo".int_table
 
+    # for RawQueryDataSource this could be a whole subquery and will therefore need to be wrapped
     if "SELECT" in table1_selection:
         table1_selection = f"({table1_selection})"
         table2_selection = f"({table2_selection})"

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -945,5 +945,7 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     """
 
     d_statisitic = engine.execute(ks_query_string).scalar()
+    n = engine.execute(f"SELECT COUNT(*) FROM ({table1_selection})").scalar()
+    m = engine.execute(f"SELECT COUNT(*) FROM ({table2_selection})").scalar()
 
-    return d_statisitic
+    return d_statisitic, n, m

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -928,46 +928,54 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     # https://github.com/Quantco/datajudge/pull/28#issuecomment-1165587929
     ks_query_string = f"""
         WITH
-        tab1 AS (
-            SELECT val, MAX(cdf) as cdf
-            FROM (SELECT val, cume_dist() over (order by val) as cdf
-                FROM (SELECT {col1} as val
-                      FROM {table1_selection} as temp01) as temp03 -- Change TABLE and COL here
-                ) as temp05
-            GROUP BY val
+        tab1 AS ( -- Step 0: Prepare data source and value column
+            SELECT {col1} as val FROM {table1_selection}
         ),
         tab2 AS (
+            SELECT {col2} as val FROM {table2_selection}
+        ),
+        tab1_cdf AS ( -- Step 1: Calculate the CDF over the value column
+            SELECT val, cume_dist() over (order by val) as cdf
+            FROM tab1
+        ),
+        tab2_cdf AS (
+            SELECT val, cume_dist() over (order by val) as cdf
+            FROM tab2
+        ),
+        tab1_grouped AS ( -- Step 2: Remove unnecessary values, s.t. we have (x, cdf(x)) rows only
             SELECT val, MAX(cdf) as cdf
-            FROM (SELECT val, cume_dist() over (order by val) as cdf
-                FROM (SELECT {col2} as val
-                      FROM {table2_selection} as temp02) as temp04 -- Change TABLE and COL here
-                ) as temp06
+            FROM tab1_cdf
             GROUP BY val
         ),
-        cdf_unfilled AS (
-            SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
-            FROM tab1 FULL OUTER JOIN tab2 ON tab1.val = tab2.val
+        tab2_grouped AS (
+            SELECT val, MAX(cdf) as cdf
+            FROM tab2_cdf
+            GROUP BY val
         ),
-        -- Step 2: Create a grouper attribute to fill values forward
-        grouped_table AS (
+        joined_cdf AS ( -- Step 3: combine the cdfs
+            SELECT coalesce(tab1_grouped.val, tab2_grouped.val) as v, tab1_grouped.cdf as cdf1, tab2_grouped.cdf as cdf2
+            FROM tab1_grouped FULL OUTER JOIN tab2_grouped ON tab1_grouped.val = tab2_grouped.val
+        ),
+        -- Step 4: Create a grouper id based on the value count; this is just a helper for forward-filling
+        grouped_cdf AS (
             SELECT v,
                 COUNT(cdf1) over (order by v) as _grp1,
                 cdf1,
                 COUNT(cdf2) over (order by v) as _grp2,
                 cdf2
-            FROM cdf_unfilled
+            FROM joined_cdf
         ),
-        -- Step 3: Select first non-null value per group (defined by grouper)
+        -- Step 5: Forward-Filling: Select first non-null value per group (defined in the prev. step)
         filled_cdf AS (
             SELECT v,
                 first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
                 first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
-            FROM grouped_table),
-        -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
+            FROM grouped_cdf),
+        -- Step 6: Replace NULL values (at the beginning) with 0 to calculate difference
         replaced_nulls AS (
             SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
             FROM filled_cdf)
-        -- Step 5: Calculate final statistic as max. distance
+        -- Step 7: Calculate final statistic as max. distance
         SELECT MAX(ABS(cdf1 - cdf2)) FROM replaced_nulls;
     """
 

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -912,50 +912,54 @@ def get_ks_2sample(engine: sa.engine.Engine, table1: tuple, table2: tuple):
     table2_selection, col2 = table2
 
     if is_mssql(engine):
-        table1_selection = str(table1_selection).replace('"', "")
-        table2_selection = str(table2_selection).replace('"', "")
+        table1_selection = str(table1_selection).replace(
+            '"', ""
+        )  # tempdb.dbo.int_table
+        table2_selection = str(table2_selection).replace(
+            '"', ""
+        )  # "tempdb.dbo".int_table
 
     ks_query_string = f"""
-WITH tab1 AS (SELECT val, MAX(cdf) as cdf
-              FROM (SELECT val, cume_dist() over (order by val) as cdf
-                    FROM (SELECT {col1} as val
-                          FROM {table1_selection} as temp01) as temp03 -- Change TABLE and COL here
-                    -- ORDER BY val -- removed, because invalid in MS-SQL Server
-                    ) as temp05
-              GROUP BY val),
-     tab2 AS (SELECT val, MAX(cdf) as cdf
-              FROM (SELECT val, cume_dist() over (order by val) as cdf
-                    FROM (SELECT {col2} as val
-                          FROM {table2_selection} as temp02) as temp04 -- Change TABLE and COL here
-                    -- ORDER BY val -- removed, because invalid in MS-SQL Server
-                    ) as temp06
-              GROUP BY val),
-     cdf_unfilled AS (SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
-                      FROM tab1
-                               FULL OUTER JOIN tab2 ON tab1.val = tab2.val
-                      -- ORDER BY v -- removed, because invalid in MS-SQL Server
-                      ),
-     grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
-         SELECT v,
-                COUNT(cdf1) over (order by v) as _grp1,
-                cdf1,
-                COUNT(cdf2) over (order by v) as _grp2,
-                cdf2
-         FROM cdf_unfilled),
-     filled_cdf AS ( -- Step 3: Select first non-null value per group (defined by grouper)
-         SELECT v,
-                first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
-                first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
-         FROM grouped_table),
-     replaced_nulls AS ( -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
-         SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
-         FROM filled_cdf)
-SELECT MAX(ABS(cdf1 - cdf2))
-FROM replaced_nulls; -- Step 5: Calculate final statistic
+        WITH tab1 AS (SELECT val, MAX(cdf) as cdf
+                      FROM (SELECT val, cume_dist() over (order by val) as cdf
+                            FROM (SELECT {col1} as val
+                                  FROM ({table1_selection}) as temp01) as temp03 -- Change TABLE and COL here
+                            -- ORDER BY val -- removed, because invalid in MS-SQL Server
+                            ) as temp05
+                      GROUP BY val),
+             tab2 AS (SELECT val, MAX(cdf) as cdf
+                      FROM (SELECT val, cume_dist() over (order by val) as cdf
+                            FROM (SELECT {col2} as val
+                                  FROM ({table2_selection}) as temp02) as temp04 -- Change TABLE and COL here
+                            -- ORDER BY val -- removed, because invalid in MS-SQL Server
+                            ) as temp06
+                      GROUP BY val),
+             cdf_unfilled AS (SELECT coalesce(tab1.val, tab2.val) as v, tab1.cdf as cdf1, tab2.cdf as cdf2
+                              FROM tab1
+                                       FULL OUTER JOIN tab2 ON tab1.val = tab2.val
+                              -- ORDER BY v -- removed, because invalid in MS-SQL Server
+                              ),
+             grouped_table AS ( -- Step 2: Create a grouper attribute to fill values forward
+                 SELECT v,
+                        COUNT(cdf1) over (order by v) as _grp1,
+                        cdf1,
+                        COUNT(cdf2) over (order by v) as _grp2,
+                        cdf2
+                 FROM cdf_unfilled),
+             filled_cdf AS ( -- Step 3: Select first non-null value per group (defined by grouper)
+                 SELECT v,
+                        first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
+                        first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
+                 FROM grouped_table),
+             replaced_nulls AS ( -- Step 4: Replace NULL values (often at the begin) with 0 to calculate difference
+                 SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
+                 FROM filled_cdf)
+        SELECT MAX(ABS(cdf1 - cdf2))
+        FROM replaced_nulls; -- Step 5: Calculate final statistic
     """
 
     d_statistic = engine.execute(ks_query_string).scalar()
-    n = engine.execute(f"SELECT COUNT(*) FROM {table1_selection} as n_table").scalar()
-    m = engine.execute(f"SELECT COUNT(*) FROM {table2_selection} as m_table").scalar()
+    n = engine.execute(f"SELECT COUNT(*) FROM ({table1_selection}) as n_table").scalar()
+    m = engine.execute(f"SELECT COUNT(*) FROM ({table2_selection}) as m_table").scalar()
 
     return d_statistic, n, m

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1273,9 +1273,9 @@ class BetweenRequirement(Requirement):
                 "Column names have to be given for this test's functionality."
             )
 
-        if significance_level < 0.0 or significance_level > 1.0:
+        if significance_level <= 0.0 or significance_level > 1.0:
             raise ValueError(
-                "The requested significance level has to be between 0.0 and 1.0. Default is 0.05."
+                "The requested significance level has to be in `(0.0, 1.0]`. Default is 0.05."
             )
 
         ref = DataReference(self.data_source, [column1], condition=condition1)

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1268,6 +1268,11 @@ class BetweenRequirement(Requirement):
         The signifance_level must be a value between 0.0 and 1.0.
         """
 
+        if not column1 or not column2:
+            raise ValueError(
+                "Column names have to be given for this test's functionality."
+            )
+
         if significance_level < 0.0 or significance_level > 1.0:
             raise ValueError(
                 "The requested significance level has to be between 0.0 and 1.0. Default is 0.05."

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@ import itertools
 import os
 import urllib.parse
 
+import numpy as np
 import pytest
 import sqlalchemy as sa
 
@@ -656,6 +657,30 @@ def groupby_aggregation_table_incorrect(engine, metadata):
         {"some_id": id, "extra_id": e, "value": v}
         for id, e, values in data_source
         for v in values
+    ]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
+@pytest.fixture(scope="module")
+def random_normal_table(engine, metadata):
+    """
+    Table containing 10_000 randomly distributed values with mean = 0 and std.dev = 1.
+    """
+    table_name = "random_normal_table"
+    columns = [
+        sa.Column("value_0_1", sa.Float()),
+        sa.Column("value_02_1", sa.Float()),
+        sa.Column("value_1_1", sa.Float()),
+    ]
+    row_size = 10_000
+    rand1 = np.random.normal(0, 1, size=(row_size,))
+    rand2 = np.random.normal(0.2, 1, size=(row_size,))
+    rand3 = np.random.normal(1, 1, size=(row_size,))
+    data_source = np.vstack((rand1, rand2, rand3))
+    data = [
+        {"value_0_1": d1, "value_02_1": d2, "value_1_1": d3}
+        for d1, d2, d3 in data_source.T
     ]
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -674,6 +674,7 @@ def random_normal_table(engine, metadata):
         sa.Column("value_1_1", sa.Float()),
     ]
     row_size = 10_000
+    np.random.seed(0)
     rand1 = np.random.normal(0, 1, size=(row_size,))
     rand2 = np.random.normal(0.2, 1, size=(row_size,))
     rand3 = np.random.normal(1, 1, size=(row_size,))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import os
+import random
 import urllib.parse
 
 import numpy as np
@@ -675,13 +676,12 @@ def random_normal_table(engine, metadata):
     ]
     row_size = 10_000
     np.random.seed(0)
-    rand1 = np.random.normal(0, 1, size=(row_size,))
-    rand2 = np.random.normal(0.2, 1, size=(row_size,))
-    rand3 = np.random.normal(1, 1, size=(row_size,))
-    data_source = np.vstack((rand1, rand2, rand3))
+    rand1 = [random.gauss(0, 1) for _ in range(row_size)]
+    rand2 = [random.gauss(0.2, 1) for _ in range(row_size)]
+    rand3 = [random.gauss(1, 1) for _ in range(row_size)]
     data = [
-        {"value_0_1": d1, "value_02_1": d2, "value_1_1": d3}
-        for d1, d2, d3 in data_source.T
+        {"value_0_1": rand1[idx], "value_02_1": rand2[idx], "value_1_1": rand3[idx]}
+        for idx in range(row_size)
     ]
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,6 @@ import os
 import random
 import urllib.parse
 
-import numpy as np
 import pytest
 import sqlalchemy as sa
 
@@ -671,16 +670,23 @@ def random_normal_table(engine, metadata):
     table_name = "random_normal_table"
     columns = [
         sa.Column("value_0_1", sa.Float()),
+        sa.Column("value_005_1", sa.Float()),
         sa.Column("value_02_1", sa.Float()),
         sa.Column("value_1_1", sa.Float()),
     ]
     row_size = 10_000
-    np.random.seed(0)
+    random.seed(0)
     rand1 = [random.gauss(0, 1) for _ in range(row_size)]
-    rand2 = [random.gauss(0.2, 1) for _ in range(row_size)]
-    rand3 = [random.gauss(1, 1) for _ in range(row_size)]
+    rand2 = [random.gauss(0.05, 1) for _ in range(row_size)]
+    rand3 = [random.gauss(0.2, 1) for _ in range(row_size)]
+    rand4 = [random.gauss(1, 1) for _ in range(row_size)]
     data = [
-        {"value_0_1": rand1[idx], "value_02_1": rand2[idx], "value_1_1": rand3[idx]}
+        {
+            "value_0_1": rand1[idx],
+            "value_005_1": rand2[idx],
+            "value_02_1": rand3[idx],
+            "value_1_1": rand4[idx],
+        }
         for idx in range(row_size)
     ]
     _handle_table(engine, metadata, table_name, columns, data)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1875,8 +1875,10 @@ def test_ks_2sample_implementation(engine, random_normal_table, configuration):
     data2, _ = db_access.get_column(engine, ref2)
 
     assert (
-        abs(d_statistic - expected_d) <= 1e-50
+        abs(d_statistic - expected_d) <= 1e-10
     ), f"The test statistic does not match: {expected_d} vs {d_statistic}"
+
+    # 1e-05 should cover common p_values; if scipy is installed, a very accurate p_value is automatically calculated
     assert (
-        abs(p_value - expected_p) <= 1e-10
+        abs(p_value - expected_p) <= 1e-05
     ), f"The approx. p-value does not match: {expected_p} vs {p_value}"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,7 +3,6 @@ import functools
 import pytest
 
 import datajudge.requirements as requirements
-from datajudge import db_access
 from datajudge.constraints.stats import KolmogorovSmirnov2Sample
 from datajudge.db_access import (
     Condition,
@@ -1856,9 +1855,9 @@ def test_ks_2sample_implementation(engine, random_normal_table, configuration):
     ref2 = DataReference(tds, columns=[col_2])
 
     # retrieve table selections from data references
-    selection1 = str(ref.data_source.get_clause(engine))
+    selection1 = ref.data_source.get_clause(engine)
     column1 = ref.get_column(engine)
-    selection2 = str(ref2.data_source.get_clause(engine))
+    selection2 = ref2.data_source.get_clause(engine)
     column2 = ref2.get_column(engine)
 
     (
@@ -1869,10 +1868,6 @@ def test_ks_2sample_implementation(engine, random_normal_table, configuration):
     ) = KolmogorovSmirnov2Sample.calculate_statistic(
         engine, (selection1, column1), (selection2, column2)
     )
-
-    # compare with scipy implementation
-    data1, _ = db_access.get_column(engine, ref)
-    data2, _ = db_access.get_column(engine, ref2)
 
     assert (
         abs(d_statistic - expected_d) <= 1e-10

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1783,15 +1783,7 @@ def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
 
 @pytest.mark.parametrize(
     "data",
-    [
-        (negation, "col_int", "col_int", 0.05),
-        (
-            identity,
-            "col_int",
-            "col_int",
-            0.0,
-        ),  # test should succeed although data is different
-    ],
+    [(negation, "col_int", "col_int", 0.05)],
 )
 def test_ks_2sample_constraint_wrong_between(
     engine, int_table1, int_square_table, data

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1841,7 +1841,7 @@ def test_ks_2sample_random(engine, random_normal_table, configuration):
 
 @pytest.mark.parametrize(
     "configuration",
-    [
+    [  # these values were calculated using scipy.stats.ks_2samp on scipy=1.8.1
         ("value_0_1", "value_0_1", 0.0, 1.0),
         ("value_0_1", "value_005_1", 0.0294, 0.00035221594346540835),
         ("value_0_1", "value_02_1", 0.0829, 2.6408848561586672e-30),
@@ -1850,7 +1850,6 @@ def test_ks_2sample_random(engine, random_normal_table, configuration):
 )
 def test_ks_2sample_implementation(engine, random_normal_table, configuration):
     col_1, col_2, expected_d, expected_p = configuration
-    # different order because schema is optional
     database, schema, table = random_normal_table
     tds = TableDataSource(database, table, schema)
     ref = DataReference(tds, columns=[col_1])


### PR DESCRIPTION
Hey!

in this PR I'd like to refactor the work of #23 and now implement the Kolmogorov-Smirnov test in SQL-only.
This has the benefit that for large datasets, we won't have to load in all the values to pass them to scipy.
Additionally, this would remove scipy as a dependency again! 🥳 

The core work of this PR consists of creating an SQL query that is able to calculate the [Kolmogorov-Smirnov test](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test#Two-sample_Kolmogorov.E2.80.93Smirnov_test). 

The idea behind this implementation as well as some theoretical backgrounds will be explained in the comments below. 

The following issues will definitely need to be addressed:

- [x] Create more tests, especially with very large datasets
- [x] Refactor tests as p_values are not always available now
- [x] ~Remove scipy dependency~ needs to be done on conda-feedstock
- [x] Test if the query is really database-agnostic, i.e., follows some SQL standard 
- [x] ~Transform query to `sqlalchemy`'s query API~ #29 issue opened
- [x] Validate p-value approximation