### PR TITLE
fixed typos in docs

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,7 +1,7 @@
 Development
 ===========
 
-In order to work on ``datajudge``, you can create development conda environment as follows:
+In order to work on ``datajudge``, you can create a development conda environment as follows:
 
 ::
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -89,7 +89,7 @@ while the latter would translate to
    #rows_table_2 > (1 + date_growth) * #rows_table_1
 
 
-In the latter case a date column must be passed during the instantiation of the ``BetweenRequirement``. Moreover, the  and ``date_range_*`` must be passed
+In the latter case a date column must be passed during the instantiation of the ``BetweenRequirement``. Moreover, the ``date_range_*`` must be passed
 in the respective ``add_*_constraint`` method. When using date ranges as an indicator of change, the ``constant_max_*`` argument can safely be ignored. Additionally,
 an additional buffer to the date growth can be added with help of the ``date_range_gain_deviation`` parameter:
 

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -207,7 +207,7 @@ class WithinRequirement(Requirement):
         reduce_func: Callable[[Collection], Collection] = None,
         condition: Condition = None,
     ):
-        """Check if unique calues of columns are contained in the reference data.
+        """Check if unique values of columns are contained in the reference data.
 
         The `UniquesSuperset` constraint asserts that reference set of expected values,
         specified via `uniques`, is contained in given columns of a `DataSource`.
@@ -949,7 +949,7 @@ class BetweenRequirement(Requirement):
         condition1: Condition = None,
         condition2: Condition = None,
     ):
-        """Check if unique calues of columns are contained in the reference data.
+        """Check if unique values of columns are contained in the reference data.
 
         The `UniquesSuperset` constraint asserts that reference set of expected values,
         derived from the unique values in given columns of the reference `DataSource`,


### PR DESCRIPTION
Was reading through the docs to get started on a project, and noticed a few typos!