### PR TITLE
Improve varchar regex assertion message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+1.2.0 - 2022.xx.xx
+------------------
+
+**New features**
+
+- Implemented specification of number of counterexamples in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
+
+
 1.1.1 - 2022.06.30
 ------------------
 

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -71,7 +71,7 @@ class VarCharRegex(Constraint):
                 f"{self.ref.get_string()} "
                 f"breaks regex '{self.ref_value}' in {n_relative_violations} > "
                 f"{self.relative_tolerance} of the cases. "
-                f"Some counterexamples consist of the following: {counterexamples} "
+                f"Some counterexamples consist of the following: {counterexamples}. "
                 f"{self.condition_string}"
             )
             return TestResult.failure(assertion_text)

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -10,17 +10,6 @@ from .base import Constraint, OptionalSelections, TestResult
 
 
 class VarCharRegex(Constraint):
-    """
-    Assesses whether the values in a column match a given regex pattern.
-
-    The option `allow_none` can be used in cases where the column is defined as nullable and contains null values.
-
-    How the tolerance factor is calculated can be controlled with the `aggregated` flag. When `True`,
-
-    the tolerance is calculated using unique values. If not, the tolerance is calculated using all the instances
-    of the data.
-    """
-
     def __init__(
         self,
         ref: DataReference,

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -53,9 +53,12 @@ class VarCharRegex(Constraint):
                 sum(uniques_counter[key] for key in uniques_mismatching) / total
             )
 
-        counterexamples = list(
-            itertools.islice(uniques_mismatching, self.n_counterexamples)
-        )
+        if self.n_counterexamples == -1:
+            counterexamples = list(uniques_mismatching)
+        else:
+            counterexamples = list(
+                itertools.islice(uniques_mismatching, self.n_counterexamples)
+            )
 
         if n_relative_violations > self.relative_tolerance:
             assertion_text = (

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -1,6 +1,6 @@
+import itertools
 import re
 from typing import Optional, Tuple
-import itertools
 
 import sqlalchemy as sa
 
@@ -64,7 +64,9 @@ class VarCharRegex(Constraint):
                 sum(uniques_counter[key] for key in uniques_mismatching) / total
             )
 
-        counterexamples = list(itertools.islice(uniques_mismatching, self.n_counterexamples))
+        counterexamples = list(
+            itertools.islice(uniques_mismatching, self.n_counterexamples)
+        )
 
         if n_relative_violations > self.relative_tolerance:
             assertion_text = (

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -46,12 +46,13 @@ class VarCharRegex(Constraint):
         }
 
         if self.aggregated:
-            n_relative_violations = len(uniques_mismatching) / len(uniques_factual)
+            n_violations = len(uniques_mismatching)
+            n_total = len(uniques_factual)
         else:
-            total = sum(count for _, count in uniques_counter.items())
-            n_relative_violations = (
-                sum(uniques_counter[key] for key in uniques_mismatching) / total
-            )
+            n_violations = sum(uniques_counter[key] for key in uniques_mismatching)
+            n_total = sum(count for _, count in uniques_counter.items())
+
+        n_relative_violations = n_violations / n_total
 
         if self.n_counterexamples == -1:
             counterexamples = list(uniques_mismatching)
@@ -65,6 +66,7 @@ class VarCharRegex(Constraint):
                 f"{self.ref.get_string()} "
                 f"breaks regex '{self.ref_value}' in {n_relative_violations} > "
                 f"{self.relative_tolerance} of the cases. "
+                f"In absolute terms, {n_violations} of the {n_total} samples violated the regex. "
                 f"Some counterexamples consist of the following: {counterexamples}. "
                 f"{self.condition_string}"
             )

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -306,7 +306,7 @@ class DataReference:
     def get_column_selection_string(self):
         if self.columns is None:
             return " * "
-        return ", ".join(self.columns)
+        return ", ".join(map(lambda x: f"'{x}'", self.columns))
 
     def get_clause_string(self, *, return_where=True):
         where_string = "WHERE " if return_where else ""
@@ -315,7 +315,7 @@ class DataReference:
     def get_string(self):
         if self.columns is None:
             return str(self.data_source)
-        return f"{self.data_source}'s columns " f" {self.get_column_selection_string()}"
+        return f"{self.data_source}'s column(s) {self.get_column_selection_string()}"
 
 
 def merge_conditions(condition1, condition2):

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -593,6 +593,20 @@ class WithinRequirement(Requirement):
         aggregated: bool = True,
         n_counterexamples: int = 5,
     ):
+        """
+        Assesses whether the values in a column match a given regular expresion pattern.
+
+        The option ``allow_none`` can be used in cases where the column is defined as
+        nullable and contains null values.
+
+        How the tolerance factor is calculated can be controlled with the ``aggregated``
+        flag. When ``True``, the tolerance is calculated using unique values. If not, the
+        tolerance is calculated using all the instances of the data.
+
+        ``n_counterexamples`` defines how many counterexamples are displayed in an
+        assertion text. If all counterexamples are meant to be shown, provide ``-1`` as
+        an argument.
+        """
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(
             varchar_constraints.VarCharRegex(

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -591,6 +591,7 @@ class WithinRequirement(Requirement):
         allow_none: bool = False,
         relative_tolerance: float = 0.0,
         aggregated: bool = True,
+        n_counterexamples: int = 5,
     ):
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(
@@ -600,6 +601,7 @@ class WithinRequirement(Requirement):
                 allow_none=allow_none,
                 relative_tolerance=relative_tolerance,
                 aggregated=aggregated,
+                n_counterexamples=n_counterexamples,
             )
         )
 


### PR DESCRIPTION
Changes:
* Adapt the formatting of the assertion message.
* Cap the number of counterexamples displayed in the assertion message.


Previously:

```AssertionError: string_table's columns  name breaks regex ^QuantCo for example values {'Google', 'BMW', 'Apple'}for a fraction '0.5' over the accepted tolerance '0.0'```

Now:

```AssertionError: string_table's column(s) 'name' breaks regex '^QuantCo' in 0.5 > 0.0 of the cases. In absolute terms, 3 of the 6 samples violated the regex. Some counterexamples consist of the following: ['Apple', 'Google', 'BMW'].```
