### PR TITLE
Provide implementation of in-database `VarCharRegex` constraint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changelog
 **New features**
 
 - Implemented specification of number of counterexamples in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
+- Implemented in-database regex matching for some dialects via ``computation_in_db`` parameter in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
+
 
 **Bug fix:**
 

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -34,12 +34,12 @@ class VarCharRegexDb(Constraint):
             regex=self.regex,
             n_counterexamples=self.n_counterexamples,
         )
-        if not self.aggregated:
-            n_rows, n_rows_selections = db_access.get_row_count(engine=engine, ref=ref)
-        else:
+        if self.aggregated:
             n_rows, n_rows_selections = db_access.get_unique_count(
                 engine=engine, ref=ref
             )
+        else:
+            n_rows, n_rows_selections = db_access.get_row_count(engine=engine, ref=ref)
         return (
             n_violations,
             n_rows,

--- a/src/datajudge/constraints/varchar.py
+++ b/src/datajudge/constraints/varchar.py
@@ -54,13 +54,20 @@ class VarCharRegexDb(Constraint):
         ) = violations_factual
         factual_relative_violations = factual_n_violations / factual_n_rows
         result = factual_relative_violations <= violations_target
+        counterexample_string = (
+            (
+                "Some counterexamples consist of the following: "
+                f"{factual_counterexamples}. "
+            )
+            if factual_counterexamples and len(factual_counterexamples) > 0
+            else ""
+        )
         assertion_text = (
             f"{self.ref.get_string()} "
             f"breaks regex '{self.regex}' in {factual_relative_violations} > "
             f"{violations_target} of the cases. "
             f"In absolute terms, {factual_n_violations} of the {factual_n_rows} samples "
-            "violated the regex. Some counterexamples consist of the following: "
-            f"{factual_counterexamples}. {self.condition_string}"
+            f"violated the regex. {counterexample_string}{self.condition_string}"
         )
         return result, assertion_text
 
@@ -117,14 +124,19 @@ class VarCharRegex(Constraint):
                 itertools.islice(uniques_mismatching, self.n_counterexamples)
             )
 
+        counterexample_string = (
+            ("Some counterexamples consist of the following: " f"{counterexamples}. ")
+            if counterexamples and len(counterexamples) > 0
+            else ""
+        )
+
         if n_relative_violations > self.relative_tolerance:
             assertion_text = (
                 f"{self.ref.get_string()} "
                 f"breaks regex '{self.ref_value}' in {n_relative_violations} > "
                 f"{self.relative_tolerance} of the cases. "
                 f"In absolute terms, {n_violations} of the {n_total} samples violated the regex. "
-                f"Some counterexamples consist of the following: {counterexamples}. "
-                f"{self.condition_string}"
+                f"{counterexample_string}{self.condition_string}"
             )
             return TestResult.failure(assertion_text)
         return TestResult.success()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1018,9 +1018,10 @@ def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):
             counterexamples_result = connection.execute(
                 counterexamples_selection
             ).fetchall()
+            counterexamples = [result[0] for result in counterexamples_result]
         else:
-            counterexamples_result = None
-    return (n_violations_result, counterexamples_result), [
+            counterexamples = None
+    return (n_violations_result, counterexamples), [
         n_violations_selection,
         counterexamples_selection,
     ]

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1003,6 +1003,8 @@ def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):
         violation_selection.subquery()
     )
 
+    selections = [n_violations_selection]
+
     if n_counterexamples == -1:
         counterexamples_selection = violation_selection
     elif n_counterexamples == 0:
@@ -1012,6 +1014,9 @@ def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):
     else:
         raise ValueError(f"Unexpected number of counterexamples: {n_counterexamples}")
 
+    if counterexamples_selection is not None:
+        selections.append(counterexamples_selection)
+
     with engine.connect() as connection:
         n_violations_result = connection.execute(n_violations_selection).scalar()
         if counterexamples_selection is not None:
@@ -1020,8 +1025,5 @@ def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):
             ).fetchall()
             counterexamples = [result[0] for result in counterexamples_result]
         else:
-            counterexamples = None
-    return (n_violations_result, counterexamples), [
-        n_violations_selection,
-        counterexamples_selection,
-    ]
+            counterexamples = []
+    return (n_violations_result, counterexamples), selections

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -988,3 +988,39 @@ def get_ks_2sample(
     ).scalar()
 
     return d_statistic, n_samples, m_samples
+
+
+def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):
+    subquery = ref.get_selection(engine)
+    column = ref.get_column(engine)
+    if aggregated:
+        subquery = subquery.distinct()
+    subquery = subquery.subquery()
+    violation_selection = sa.select(subquery.c[column]).where(
+        sa.not_(subquery.c[column].regexp_match(regex))
+    )
+    n_violations_selection = sa.select([sa.func.count()]).select_from(
+        violation_selection.subquery()
+    )
+
+    if n_counterexamples == -1:
+        counterexamples_selection = violation_selection
+    elif n_counterexamples == 0:
+        counterexamples_selection = None
+    elif n_counterexamples > 0:
+        counterexamples_selection = violation_selection.limit(n_counterexamples)
+    else:
+        raise ValueError(f"Unexpected number of counterexamples: {n_counterexamples}")
+
+    with engine.connect() as connection:
+        n_violations_result = connection.execute(n_violations_selection).scalar()
+        if counterexamples_selection is not None:
+            counterexamples_result = connection.execute(
+                counterexamples_selection
+            ).fetchall()
+        else:
+            counterexamples_result = None
+    return (n_violations_result, counterexamples_result), [
+        n_violations_selection,
+        counterexamples_selection,
+    ]

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1019,11 +1019,11 @@ def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):
 
     with engine.connect() as connection:
         n_violations_result = connection.execute(n_violations_selection).scalar()
-        if counterexamples_selection is not None:
+        if counterexamples_selection is None:
+            counterexamples = []
+        else:
             counterexamples_result = connection.execute(
                 counterexamples_selection
             ).fetchall()
             counterexamples = [result[0] for result in counterexamples_result]
-        else:
-            counterexamples = []
     return (n_violations_result, counterexamples), selections

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -611,7 +611,8 @@ class WithinRequirement(Requirement):
 
         ``computation_in_db`` defines whether the regex matching takes place in database or
         in memory. Typically the former is both faster and substantially more memory-saving.
-        Yet, it is only supported for Postrres, sqllite and Snowflake.
+        Yet, it is only supported for Postgres, Sqllite and Snowflake. Note that for this
+        feature is only for Snowflake when using sqlalchemy-snowflake >= 1.4.0.
         """
         ref = DataReference(self.data_source, [column], condition)
         if computation_in_db:
@@ -619,7 +620,7 @@ class WithinRequirement(Requirement):
                 warnings.warn(
                     """
                     Parameter 'allow_none' is not allowed when using 'computation_in_db'.
-                    Please use a Condition with of the sort 'column IS NOT NULL' instead.
+                    Please use a Condition of the sort 'column IS NOT NULL' instead.
                     """
                 )
             self._constraints.append(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,11 +19,6 @@ def skip_if_mssql(engine):
         pytest.skip("functionality not supported by SQL Server")
 
 
-def skip_if_not_mssql(engine):
-    if not is_mssql(engine):
-        pytest.skip("functionality only supported by SQL Server")
-
-
 def identity(boolean_value):
     return boolean_value
 
@@ -1298,7 +1293,6 @@ def test_varchar_regex_within(engine, mix_table1, computation_in_db, data):
     ],
 )
 def test_varchar_regex_with_none_within(engine, varchar_table1, data):
-    skip_if_not_mssql(engine)
     (operation, regex, condition, allow) = data
     req = requirements.WithinRequirement.from_table(*varchar_table1)
     req.add_varchar_regex_constraint(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1273,7 +1273,11 @@ def test_date_no_gap_within_inclusion_exclusion(engine, date_table_gap, data):
 )
 def test_varchar_regex_within(engine, mix_table1, computation_in_db, data):
     if computation_in_db:
-        skip_if_mssql(engine)
+        # TODO: This feature is available in snowflake-sqlalchemy 1.4.0.
+        # Once we remove or update the pinned version, we can enable this test
+        # for snowflake.
+        if is_mssql(engine) or is_snowflake(engine):
+            pytest.skip("Functionality not supported by given dialect.")
     (operation, regex, condition) = data
     req = requirements.WithinRequirement.from_table(*mix_table1)
     req.add_varchar_regex_constraint(
@@ -1319,7 +1323,11 @@ def test_varchar_regex_with_none_within(engine, varchar_table1, data):
 )
 def test_varchar_regex_tolerance(engine, varchar_table_real, computation_in_db, data):
     if computation_in_db:
-        skip_if_mssql(engine)
+        # TODO: This feature is available in snowflake-sqlalchemy 1.4.0.
+        # Once we remove or update the pinned version, we can enable this test
+        # for snowflake.
+        if is_mssql(engine) or is_snowflake(engine):
+            pytest.skip("Functionality not supported by given dialect.")
     (operation, condition, aggregated, tolerance) = data
     req = requirements.WithinRequirement.from_table(*varchar_table_real)
     req.add_varchar_regex_constraint(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1267,20 +1267,25 @@ def test_date_no_gap_within_inclusion_exclusion(engine, date_table_gap, data):
     ],
 )
 def test_varchar_regex_within(engine, mix_table1, computation_in_db, data):
+    (operation, regex, condition) = data
+    req = requirements.WithinRequirement.from_table(*mix_table1)
     if computation_in_db:
         # TODO: This feature is available in snowflake-sqlalchemy 1.4.0.
         # Once we remove or update the pinned version, we can enable this test
         # for snowflake.
         if is_mssql(engine) or is_snowflake(engine):
             pytest.skip("Functionality not supported by given dialect.")
-    (operation, regex, condition) = data
-    req = requirements.WithinRequirement.from_table(*mix_table1)
-    req.add_varchar_regex_constraint(
-        column="col_varchar",
-        regex=regex,
-        computation_in_db=computation_in_db,
-        condition=condition,
-    )
+        req.add_varchar_regex_constraint_db(
+            column="col_varchar",
+            regex=regex,
+            condition=condition,
+        )
+    else:
+        req.add_varchar_regex_constraint(
+            column="col_varchar",
+            regex=regex,
+            condition=condition,
+        )
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
 
@@ -1316,22 +1321,29 @@ def test_varchar_regex_with_none_within(engine, varchar_table1, data):
     ],
 )
 def test_varchar_regex_tolerance(engine, varchar_table_real, computation_in_db, data):
+    (operation, condition, aggregated, tolerance) = data
+    req = requirements.WithinRequirement.from_table(*varchar_table_real)
     if computation_in_db:
         # TODO: This feature is available in snowflake-sqlalchemy 1.4.0.
         # Once we remove or update the pinned version, we can enable this test
         # for snowflake.
         if is_mssql(engine) or is_snowflake(engine):
             pytest.skip("Functionality not supported by given dialect.")
-    (operation, condition, aggregated, tolerance) = data
-    req = requirements.WithinRequirement.from_table(*varchar_table_real)
-    req.add_varchar_regex_constraint(
-        "col_varchar",
-        r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
-        condition=condition,
-        computation_in_db=computation_in_db,
-        relative_tolerance=tolerance,
-        aggregated=aggregated,
-    )
+        req.add_varchar_regex_constraint_db(
+            "col_varchar",
+            r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
+            condition=condition,
+            relative_tolerance=tolerance,
+            aggregated=aggregated,
+        )
+    else:
+        req.add_varchar_regex_constraint(
+            "col_varchar",
+            r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
+            condition=condition,
+            relative_tolerance=tolerance,
+            aggregated=aggregated,
+        )
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
 
@@ -1354,22 +1366,30 @@ def test_varchar_regex_counterexample(
     n_counterexamples,
     n_received_counterexamples,
 ):
+    req = requirements.WithinRequirement.from_table(*varchar_table_real)
     if computation_in_db:
         # TODO: This feature is available in snowflake-sqlalchemy 1.4.0.
         # Once we remove or update the pinned version, we can enable this test
         # for snowflake.
         if is_mssql(engine) or is_snowflake(engine):
             pytest.skip("Functionality not supported by given dialect.")
-    req = requirements.WithinRequirement.from_table(*varchar_table_real)
-    req.add_varchar_regex_constraint(
-        "col_varchar",
-        r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
-        condition=None,
-        computation_in_db=computation_in_db,
-        relative_tolerance=0,
-        aggregated=True,
-        n_counterexamples=n_counterexamples,
-    )
+        req.add_varchar_regex_constraint_db(
+            "col_varchar",
+            r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
+            condition=None,
+            relative_tolerance=0,
+            aggregated=True,
+            n_counterexamples=n_counterexamples,
+        )
+    else:
+        req.add_varchar_regex_constraint(
+            "col_varchar",
+            r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
+            condition=None,
+            relative_tolerance=0,
+            aggregated=True,
+            n_counterexamples=n_counterexamples,
+        )
     test_result = req[0].test(engine)
     failure_message = test_result.failure_message
     # If no counterexample are given, this marker should not be present in the
@@ -1394,22 +1414,30 @@ def test_varchar_regex_counterexample(
 def test_varchar_regex_counterexample_invalid(
     engine, varchar_table_real, computation_in_db, n_counterexamples
 ):
+    req = requirements.WithinRequirement.from_table(*varchar_table_real)
     if computation_in_db:
         # TODO: This feature is available in snowflake-sqlalchemy 1.4.0.
         # Once we remove or update the pinned version, we can enable this test
         # for snowflake.
         if is_mssql(engine) or is_snowflake(engine):
             pytest.skip("Functionality not supported by given dialect.")
-    req = requirements.WithinRequirement.from_table(*varchar_table_real)
-    req.add_varchar_regex_constraint(
-        "col_varchar",
-        r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
-        condition=None,
-        computation_in_db=computation_in_db,
-        relative_tolerance=0,
-        aggregated=True,
-        n_counterexamples=n_counterexamples,
-    )
+        req.add_varchar_regex_constraint_db(
+            "col_varchar",
+            r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
+            condition=None,
+            relative_tolerance=0,
+            aggregated=True,
+            n_counterexamples=n_counterexamples,
+        )
+    else:
+        req.add_varchar_regex_constraint(
+            "col_varchar",
+            r"[A-Z][0-9]{2}\.[0-9]{0,2}$",
+            condition=None,
+            relative_tolerance=0,
+            aggregated=True,
+            n_counterexamples=n_counterexamples,
+        )
     with pytest.raises(ValueError):
         req[0].test(engine)
 


### PR DESCRIPTION
The current implementation of `VarCharRegex` fetches all rows from database to memory and matches them against a regex via a Python implementation.

This has several downsides:
- Heavy/slow on network in the case of snowflake
- Substantially larger memory cost
- Usually longer runtime
- Inconsistency with the datajudge paradigm to do heavy lifting in database

Instead, this PR seeks to offer the in-database matching of regexes for some database systems. More precisely, this change relies on `sqlalchemy`'s relatively new `regexp_match`[0] method. According to their documentation:

> Regular expression support is currently implemented for Oracle, PostgreSQL, MySQL and MariaDB. Partial support is available for SQLite. Support among third-party dialects may vary.

As of now, tests for the in-database computation run only against Postgres. I also ran them locally against Snowflake, which succeeded but relies on `snowflake-sqlalchemy` version 1.4.0. As long as this [1] bug isn't fixed, we can't enable the tests against snowflake in CI since we still need version <1.4.0.

Put differently, an eager user can install `snowflake-sqlalchemy` version 1.4.0 and make use of this feature.

<img width="932" alt="Screenshot 2022-07-27 at 12 49 38 PM" src="https://user-images.githubusercontent.com/7267523/181229594-793920ec-2ffd-46ab-ba35-2cc8dcf78067.png">


[0] https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_match
[1] https://github.com/Quantco/datajudge/issues/39