### PR TITLE
Reimplement Kolmogorov Smirnov query logic with sqlalchemy's Language Expression API

### DIFF
--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,6 +1,6 @@
 import math
 import warnings
-from typing import Optional, Tuple
+from typing import Optional
 
 import sqlalchemy as sa
 
@@ -73,50 +73,63 @@ class KolmogorovSmirnov2Sample(Constraint):
         engine,
         ref1: DataReference,
         ref2: DataReference,
-    ) -> Tuple[float, Optional[float], int, int]:
+    ) -> tuple[float, Optional[float], int, int, list]:
 
         # retrieve test statistic d, as well as sample sizes m and n
-        d_statistic = db_access.get_ks_2sample(
+        d_statistic, ks_selections = db_access.get_ks_2sample(
             engine,
             ref1,
             ref2,
         )
 
-        n_samples, _ = db_access.get_row_count(engine, ref1)
-        m_samples, _ = db_access.get_row_count(engine, ref2)
+        n_samples, n_selections = db_access.get_row_count(engine, ref1)
+        m_samples, m_selections = db_access.get_row_count(engine, ref2)
 
         # calculate approximate p-value
         p_value = KolmogorovSmirnov2Sample.approximate_p_value(
             d_statistic, n_samples, m_samples
         )
 
-        return d_statistic, p_value, n_samples, m_samples
+        selections = n_selections + m_selections + ks_selections
+        return d_statistic, p_value, n_samples, m_samples, selections
 
     def test(self, engine: sa.engine.Engine) -> TestResult:
-
-        # get query selections and column names for target columns
-
-        d_statistic, p_value, n_samples, m_samples = self.calculate_statistic(
+        (
+            d_statistic,
+            p_value,
+            n_samples,
+            m_samples,
+            selections,
+        ) = self.calculate_statistic(
             engine,
             self.ref,
             self.ref2,
         )
-
-        # calculate test acceptance
         result = self.check_acceptance(
             d_statistic, n_samples, m_samples, self.significance_level
         )
 
         assertion_text = (
             f"Null hypothesis (H0) for the 2-sample Kolmogorov-Smirnov test was rejected, i.e., "
-            f"the two samples ({self.ref.get_string()} and {self.target_prefix})"
-            f" do not originate from the same distribution."
+            f"the two samples ({self.ref.get_string()} and {self.target_prefix}) "
+            f"do not originate from the same distribution. "
             f"The test results are d={d_statistic}"
         )
         if p_value is not None:
-            assertion_text += f"and {p_value=}"
+            assertion_text += f" and {p_value=}"
+        assertion_text += "."
+
+        if selections:
+            queries = [
+                str(selection.compile(engine, compile_kwargs={"literal_binds": True}))
+                for selection in selections
+            ]
 
         if not result:
-            return TestResult.failure(assertion_text)
+            return TestResult.failure(
+                assertion_text,
+                self.get_description(),
+                queries,
+            )
 
         return TestResult.success()

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -1,6 +1,6 @@
 import math
 import warnings
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import sqlalchemy as sa
 
@@ -73,7 +73,7 @@ class KolmogorovSmirnov2Sample(Constraint):
         engine,
         ref1: DataReference,
         ref2: DataReference,
-    ) -> tuple[float, Optional[float], int, int, list]:
+    ) -> Tuple[float, Optional[float], int, int, List]:
 
         # retrieve test statistic d, as well as sample sizes m and n
         d_statistic, ks_selections = db_access.get_ks_2sample(

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -63,9 +63,10 @@ class KolmogorovSmirnov2Sample(Constraint):
         def c(alpha: float):
             return math.sqrt(-math.log(alpha / 2.0 + 1e-10) * 0.5)
 
-        return d_statistic <= c(accepted_level) * math.sqrt(
+        threshold = c(accepted_level) * math.sqrt(
             (n_samples + m_samples) / (n_samples * m_samples)
         )
+        return d_statistic <= threshold
 
     @staticmethod
     def calculate_statistic(

--- a/src/datajudge/constraints/stats.py
+++ b/src/datajudge/constraints/stats.py
@@ -75,11 +75,14 @@ class KolmogorovSmirnov2Sample(Constraint):
     ) -> Tuple[float, Optional[float], int, int]:
 
         # retrieve test statistic d, as well as sample sizes m and n
-        d_statistic, n_samples, m_samples = db_access.get_ks_2sample(
+        d_statistic = db_access.get_ks_2sample(
             engine,
             ref1,
             ref2,
         )
+
+        n_samples, _ = db_access.get_row_count(engine, ref1)
+        m_samples, _ = db_access.get_row_count(engine, ref2)
 
         # calculate approximate p-value
         p_value = KolmogorovSmirnov2Sample.approximate_p_value(

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -913,65 +913,80 @@ def get_ks_2sample(
     Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
     """
     # For mssql: "tempdb.dbo".table_name -> tempdb.dbo.table_name
-    table1_str = str(ref1.data_source.get_clause(engine)).replace('"', "")
     col1 = ref1.get_column(engine)
-    table2_str = str(ref2.data_source.get_clause(engine)).replace('"', "")
     col2 = ref2.get_column(engine)
 
-    # for a more extensive explanation, see:
-    # https://github.com/Quantco/datajudge/pull/28#issuecomment-1165587929
-    ks_query_string = f"""
-        WITH
-        tab1 AS ( -- Step 0: Prepare data source and value column
-            SELECT {col1} as val FROM {table1_str}
-        ),
-        tab2 AS (
-            SELECT {col2} as val FROM {table2_str}
-        ),
-        tab1_cdf AS ( -- Step 1: Calculate the CDF over the value column
-            SELECT val, cume_dist() over (order by val) as cdf
-            FROM tab1
-        ),
-        tab2_cdf AS (
-            SELECT val, cume_dist() over (order by val) as cdf
-            FROM tab2
-        ),
-        tab1_grouped AS ( -- Step 2: Remove unnecessary values, s.t. we have (x, cdf(x)) rows only
-            SELECT val, MAX(cdf) as cdf
-            FROM tab1_cdf
-            GROUP BY val
-        ),
-        tab2_grouped AS (
-            SELECT val, MAX(cdf) as cdf
-            FROM tab2_cdf
-            GROUP BY val
-        ),
-        joined_cdf AS ( -- Step 3: combine the cdfs
-            SELECT coalesce(tab1_grouped.val, tab2_grouped.val) as v, tab1_grouped.cdf as cdf1, tab2_grouped.cdf as cdf2
-            FROM tab1_grouped FULL OUTER JOIN tab2_grouped ON tab1_grouped.val = tab2_grouped.val
-        ),
-        -- Step 4: Create a grouper id based on the value count; this is just a helper for forward-filling
-        grouped_cdf AS (
-            SELECT v,
-                COUNT(cdf1) over (order by v) as _grp1,
-                cdf1,
-                COUNT(cdf2) over (order by v) as _grp2,
-                cdf2
-            FROM joined_cdf
-        ),
-        -- Step 5: Forward-Filling: Select first non-null value per group (defined in the prev. step)
-        filled_cdf AS (
-            SELECT v,
-                first_value(cdf1) over (partition by _grp1 order by v) as cdf1_filled,
-                first_value(cdf2) over (partition by _grp2 order by v) as cdf2_filled
-            FROM grouped_cdf),
-        -- Step 6: Replace NULL values (at the beginning) with 0 to calculate difference
-        replaced_nulls AS (
-            SELECT coalesce(cdf1_filled, 0) as cdf1, coalesce(cdf2_filled, 0) as cdf2
-            FROM filled_cdf)
-        -- Step 7: Calculate final statistic as max. distance
-        SELECT MAX(ABS(cdf1 - cdf2)) FROM replaced_nulls;
-    """
+    selection1 = ref1.get_selection(engine)
+    selection2 = ref2.get_selection(engine)
 
-    d_statistic = engine.execute(ks_query_string).scalar()
+    s1 = sa.select(
+        [
+            selection1.selected_columns[col1].label("val"),
+            sa.func.cume_dist().over(order_by=col1).label("cdf"),
+        ]
+    ).subquery()
+    s2 = sa.select(
+        [
+            selection2.selected_columns[col2].label("val"),
+            sa.func.cume_dist().over(order_by=col2).label("cdf"),
+        ]
+    ).subquery()
+
+    t1 = (
+        sa.select([s1.c["val"], sa.func.max(s1.c["cdf"]).label("cdf")])
+        .group_by(s1.c["val"])
+        .subquery()
+    )
+    t2 = (
+        sa.select([s2.c["val"], sa.func.max(s2.c["cdf"]).label("cdf")])
+        .group_by(s2.c["val"])
+        .subquery()
+    )
+
+    join = (
+        sa.select(
+            sa.func.coalesce(t1.c["val"], t2.c["val"]).label("v"),
+            t1.c["cdf"].label("cdf1"),
+            t2.c["cdf"].label("cdf2"),
+        )
+        .select_from(t1.join(t2, t1.c["val"] == t2.c["val"], isouter=True, full=True))
+        .subquery()
+    )
+
+    grouped_cdf = sa.select(
+        [
+            join.c["v"],
+            sa.func.count(join.c["cdf1"]).over(order_by=join.c["v"]).label("_grp1"),
+            join.c["cdf1"],
+            sa.func.count(join.c["cdf2"]).over(order_by=join.c["v"]).label("_grp2"),
+            join.c["cdf2"],
+        ]
+    ).subquery()
+
+    filled_cdf = sa.select(
+        [
+            grouped_cdf.c["v"],
+            sa.func.first_value(grouped_cdf.c["cdf1"])
+            .over(partition_by=grouped_cdf.c["_grp1"], order_by=grouped_cdf.c["v"])
+            .label("cdf1_filled"),
+            sa.func.first_value(grouped_cdf.c["cdf2"])
+            .over(partition_by=grouped_cdf.c["_grp2"], order_by=grouped_cdf.c["v"])
+            .label("cdf2_filled"),
+        ]
+    ).subquery()
+
+    replaced_nulls = sa.select(
+        [
+            sa.func.coalesce(filled_cdf.c["cdf1_filled"], 0).label("cdf1"),
+            sa.func.coalesce(filled_cdf.c["cdf2_filled"], 0).label("cdf2"),
+        ]
+    ).subquery()
+
+    final_selection = sa.select(
+        sa.func.max(sa.func.abs(replaced_nulls.c["cdf1"] - replaced_nulls.c["cdf2"]))
+    )
+
+    with engine.connect() as connection:
+        d_statistic = connection.execute(final_selection).scalar()
+
     return d_statistic

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -288,7 +288,13 @@ class DataReference:
                 f"Trying to access column of DataReference "
                 f"{self.get_string()} yet none is given."
             )
-        return self.get_columns(engine)[0]
+        columns = self.get_columns(engine)
+        if len(columns) > 1:
+            raise ValueError(
+                "DataReference was expected to only have a single column but had multiple: "
+                f"{columns}"
+            )
+        return columns[0]
 
     def get_columns(self, engine):
         """Fetch all relevant columns of a DataReference."""

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1016,7 +1016,7 @@ def _cross_cdf_selection(
                 indexed_cross_cdf, cdf_label2, value_label, group_label2
             ),
         ]
-    ).subquery()
+    )
     return filled_cross_cdf, cdf_label1, cdf_label2
 
 
@@ -1030,9 +1030,11 @@ def get_ks_2sample(
     """
     cdf_label = "cdf"
     value_label = "val"
-    filled_cross_cdf, cdf_label1, cdf_label2 = _cross_cdf_selection(
+    filled_cross_cdf_selection, cdf_label1, cdf_label2 = _cross_cdf_selection(
         engine, ref1, ref2, cdf_label, value_label
     )
+
+    filled_cross_cdf = filled_cross_cdf_selection.subquery()
 
     # Step 7: Calculate final statistic: maximal distance.
     final_selection = sa.select(

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -935,7 +935,7 @@ def get_ks_2sample(
     engine: sa.engine.Engine,
     ref1: DataReference,
     ref2: DataReference,
-) -> float:
+):
     """
     Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
     """
@@ -1024,7 +1024,7 @@ def get_ks_2sample(
     with engine.connect() as connection:
         d_statistic = connection.execute(final_selection).scalar()
 
-    return d_statistic
+    return d_statistic, [final_selection]
 
 
 def get_regex_violations(engine, ref, aggregated, regex, n_counterexamples):

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -923,10 +923,10 @@ def get_ks_2sample(
     ks_query_string = f"""
         WITH
         tab1 AS ( -- Step 0: Prepare data source and value column
-            SELECT aux.{col1} as val FROM {table1_str} as aux
+            SELECT {col1} as val FROM {table1_str}
         ),
         tab2 AS (
-            SELECT aux.{col2} as val FROM {table2_str} as aux
+            SELECT {col2} as val FROM {table2_str}
         ),
         tab1_cdf AS ( -- Step 1: Calculate the CDF over the value column
             SELECT val, cume_dist() over (order by val) as cdf

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -908,7 +908,7 @@ def get_ks_2sample(
     engine: sa.engine.Engine,
     ref1: DataReference,
     ref2: DataReference,
-) -> tuple[float, int, int]:
+) -> float:
     """
     Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
     """
@@ -973,6 +973,4 @@ def get_ks_2sample(
     """
 
     d_statistic = engine.execute(ks_query_string).scalar()
-    n_samples, _ = get_row_count(engine, ref1)
-    m_samples, _ = get_row_count(engine, ref2)
-    return d_statistic, n_samples, m_samples
+    return d_statistic

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -906,12 +906,12 @@ def get_column_array_agg(
 
 def _get_cdf_selection(engine, ref: DataReference, cdf_label: str, value_label: str):
     col = ref.get_column(engine)
-    selection = ref.get_selection(engine)
+    selection = ref.get_selection(engine).subquery()
 
     # Step 1: Calculate the CDF over the value column.
     cdf_selection = sa.select(
         [
-            selection.selected_columns[col].label(value_label),
+            selection.c[col].label(value_label),
             sa.func.cume_dist().over(order_by=col).label(cdf_label),
         ]
     ).subquery()

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -905,6 +905,12 @@ def get_column_array_agg(
 
 
 def _cdf_selection(engine, ref: DataReference, cdf_label: str, value_label: str):
+    """Create an empirical cumulative distribution function values.
+
+    Concretely, create a selection with values from ``value_label`` as well as
+    the empirical cumulative didistribution function values, labeled as
+    ``cdf_label``.
+    """
     col = ref.get_column(engine)
     selection = ref.get_selection(engine).subquery()
 
@@ -927,7 +933,6 @@ def _cdf_selection(engine, ref: DataReference, cdf_label: str, value_label: str)
         .group_by(cdf_selection.c[value_label])
         .subquery()
     )
-
     return grouped_cdf_selection
 
 

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -1037,7 +1037,10 @@ def get_ks_2sample(
     ref2: DataReference,
 ):
     """
-    Runs the query for the two-sample Kolmogorov-Smirnov test and returns the test statistic d.
+    Run the query for the two-sample Kolmogorov-Smirnov test and return the test statistic d.
+
+    For a raw-sql version of this query, please see this PR:
+    https://github.com/Quantco/datajudge/pull/28/
     """
     cdf_label = "cdf"
     value_label = "val"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -665,7 +665,7 @@ def groupby_aggregation_table_incorrect(engine, metadata):
 @pytest.fixture(scope="module")
 def random_normal_table(engine, metadata):
     """
-    Table containing 10_000 randomly distributed values with mean = 0 and std.dev = 1.
+    Table with normally distributed values of varying means and sd 1.
     """
     table_name = "random_normal_table"
     columns = [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -715,6 +715,28 @@ def capitalization_table(engine, metadata):
     return TEST_DB_NAME, SCHEMA, table_name, uppercase_column, lowercase_column
 
 
+@pytest.fixture(scope="module")
+def cross_cdf_table1(engine, metadata):
+    table_name = "cross_cdf_table1"
+    col_name = "col_int"
+    columns = [sa.Column(col_name, sa.Integer())]
+    col_values = [1, 1, 3, 2]
+    data = [{col_name: col_value} for col_value in col_values]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
+@pytest.fixture(scope="module")
+def cross_cdf_table2(engine, metadata):
+    table_name = "cross_cdf_table2"
+    col_name = "col_int"
+    columns = [sa.Column(col_name, sa.Integer())]
+    col_values = [3, 5, 4, 5, 8]
+    data = [{col_name: col_value} for col_value in col_values]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--backend",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1926,35 +1926,40 @@ def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
 
 
 @pytest.mark.parametrize(
-    "data",
+    "condition1, condition2",
     [
         (
-            negation,
-            "col_int",
-            "col_int",
             None,
             Condition(raw_string="col_int >= 10"),
-            1.0,
+        ),
+        (
+            Condition(raw_string="col_int >= 10"),
+            None,
+        ),
+        (
+            Condition(raw_string="col_int >= 10"),
+            Condition(raw_string="col_int >= 3"),
         ),
     ],
 )
 def test_ks_2sample_constraint_perfect_between_different_conditions(
-    engine, int_table1, data
+    engine, int_table1, condition1, condition2
 ):
     """
-    Test Kolmogorov-Smirnov for the same column -> p-value should be perfect 1.0.
+    Test Kolmogorov-Smirnov for the same column but different conditions.
+    As a consequence, since the data is distinct, the tests are expected
+    to fail for a very high significance level.
     """
-    (operation, col_1, col_2, condition1, condition2, significance_level) = data
     req = requirements.BetweenRequirement.from_tables(*int_table1, *int_table1)
     req.add_ks_2sample_constraint(
-        column1=col_1,
-        column2=col_2,
+        column1="col_int",
+        column2="col_int",
         condition1=condition1,
         condition2=condition2,
-        significance_level=significance_level,
+        significance_level=1.0,
     )
     test_result = req[0].test(engine)
-    assert operation(test_result.outcome), test_result.failure_message
+    assert negation(test_result.outcome), test_result.failure_message
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1890,10 +1890,6 @@ def test_groupby_aggregation_within_with_failures(
     assert operation(test_result.outcome), test_result.failure_message
 
 
-def test_diff_average_between():
-    return
-
-
 @pytest.mark.parametrize(
     "data",
     [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1854,20 +1854,12 @@ def test_ks_2sample_implementation(engine, random_normal_table, configuration):
     ref = DataReference(tds, columns=[col_1])
     ref2 = DataReference(tds, columns=[col_2])
 
-    # retrieve table selections from data references
-    selection1 = ref.data_source.get_clause(engine)
-    column1 = ref.get_column(engine)
-    selection2 = ref2.data_source.get_clause(engine)
-    column2 = ref2.get_column(engine)
-
     (
         d_statistic,
         p_value,
         n_samples,
         m_samples,
-    ) = KolmogorovSmirnov2Sample.calculate_statistic(
-        engine, (selection1, column1), (selection2, column2)
-    )
+    ) = KolmogorovSmirnov2Sample.calculate_statistic(engine, ref, ref2)
 
     assert (
         abs(d_statistic - expected_d) <= 1e-10

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1768,25 +1768,59 @@ def test_diff_average_between():
 @pytest.mark.parametrize(
     "data",
     [
-        (identity, "col_int", "col_int", None, 1.0),
-        (identity, "col_int", "col_int", Condition("col_int >= 3"), 1.0),
+        (identity, "col_int", "col_int", None, None, 1.0),
+        (
+            identity,
+            "col_int",
+            "col_int",
+            Condition("col_int >= 3"),
+            Condition("col_int >= 3"),
+            1.0,
+        ),
     ],
 )
 def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
     """
     Test Kolmogorov-Smirnov for the same column -> p-value should be perfect 1.0.
     """
-    (operation, col_1, col_2, condition, significance_level) = data
+    (operation, col_1, col_2, condition1, condition2, significance_level) = data
     req = requirements.BetweenRequirement.from_tables(*int_table1, *int_table1)
     req.add_ks_2sample_constraint(
         column1=col_1,
         column2=col_2,
-        condition1=condition,
-        condition2=condition,
+        condition1=condition1,
+        condition2=condition2,
         significance_level=significance_level,
     )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
 
-    assert operation(req[0].test(engine).outcome)
+
+# TODO: Enable this test once the bug is fixed.
+@pytest.mark.skip(reason="This is a known bug and unintended behaviour.")
+@pytest.mark.parametrize(
+    "data",
+    [
+        (negation, "col_int", "col_int", None, Condition("col_int >= 10"), 1.0),
+    ],
+)
+def test_ks_2sample_constraint_perfect_between_different_condition(
+    engine, int_table1, data
+):
+    """
+    Test Kolmogorov-Smirnov for the same column -> p-value should be perfect 1.0.
+    """
+    (operation, col_1, col_2, condition1, condition2, significance_level) = data
+    req = requirements.BetweenRequirement.from_tables(*int_table1, *int_table1)
+    req.add_ks_2sample_constraint(
+        column1=col_1,
+        column2=col_2,
+        condition1=condition1,
+        condition2=condition2,
+        significance_level=significance_level,
+    )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
 
 
 @pytest.mark.parametrize(
@@ -1804,8 +1838,8 @@ def test_ks_2sample_constraint_wrong_between(
     req.add_ks_2sample_constraint(
         column1=col_1, column2=col_2, significance_level=min_p_value
     )
-
-    assert operation(req[0].test(engine).outcome)
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
 
 
 @pytest.mark.parametrize(
@@ -1835,7 +1869,7 @@ def test_ks_2sample_random(engine, random_normal_table, configuration):
         column1=col_1, column2=col_2, significance_level=min_p_value
     )
     test_result = req[0].test(engine)
-    assert operation(test_result.outcome)
+    assert operation(test_result.outcome), test_result.failure_message
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1902,8 +1902,8 @@ def test_diff_average_between():
             identity,
             "col_int",
             "col_int",
-            Condition("col_int >= 3"),
-            Condition("col_int >= 3"),
+            Condition(raw_string="col_int >= 3"),
+            Condition(raw_string="col_int >= 3"),
             1.0,
         ),
     ],
@@ -1925,15 +1925,20 @@ def test_ks_2sample_constraint_perfect_between(engine, int_table1, data):
     assert operation(test_result.outcome), test_result.failure_message
 
 
-# TODO: Enable this test once the bug is fixed.
-@pytest.mark.skip(reason="This is a known bug and unintended behaviour.")
 @pytest.mark.parametrize(
     "data",
     [
-        (negation, "col_int", "col_int", None, Condition("col_int >= 10"), 1.0),
+        (
+            negation,
+            "col_int",
+            "col_int",
+            None,
+            Condition(raw_string="col_int >= 10"),
+            1.0,
+        ),
     ],
 )
-def test_ks_2sample_constraint_perfect_between_different_condition(
+def test_ks_2sample_constraint_perfect_between_different_conditions(
     engine, int_table1, data
 ):
     """

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,15 +3,7 @@ import functools
 import pytest
 
 import datajudge.requirements as requirements
-from datajudge.constraints.stats import KolmogorovSmirnov2Sample
-from datajudge.db_access import (
-    Condition,
-    DataReference,
-    TableDataSource,
-    is_mssql,
-    is_postgresql,
-    is_snowflake,
-)
+from datajudge.db_access import Condition, is_mssql, is_postgresql, is_snowflake
 
 
 def skip_if_mssql(engine):
@@ -2005,37 +1997,3 @@ def test_ks_2sample_random(engine, random_normal_table, configuration):
     )
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
-
-
-@pytest.mark.parametrize(
-    "configuration",
-    [  # these values were calculated using scipy.stats.ks_2samp on scipy=1.8.1
-        ("value_0_1", "value_0_1", 0.0, 1.0),
-        ("value_0_1", "value_005_1", 0.0294, 0.00035221594346540835),
-        ("value_0_1", "value_02_1", 0.0829, 2.6408848561586672e-30),
-        ("value_0_1", "value_1_1", 0.3924, 0.0),
-    ],
-)
-def test_ks_2sample_implementation(engine, random_normal_table, configuration):
-    col_1, col_2, expected_d, expected_p = configuration
-    database, schema, table = random_normal_table
-    tds = TableDataSource(database, table, schema)
-    ref = DataReference(tds, columns=[col_1])
-    ref2 = DataReference(tds, columns=[col_2])
-
-    (
-        d_statistic,
-        p_value,
-        n_samples,
-        m_samples,
-        _,
-    ) = KolmogorovSmirnov2Sample.calculate_statistic(engine, ref, ref2)
-
-    assert (
-        abs(d_statistic - expected_d) <= 1e-10
-    ), f"The test statistic does not match: {expected_d} vs {d_statistic}"
-
-    # 1e-05 should cover common p_values; if scipy is installed, a very accurate p_value is automatically calculated
-    assert (
-        abs(p_value - expected_p) <= 1e-05
-    ), f"The approx. p-value does not match: {expected_p} vs {p_value}"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2032,6 +2032,7 @@ def test_ks_2sample_implementation(engine, random_normal_table, configuration):
         p_value,
         n_samples,
         m_samples,
+        _,
     ) = KolmogorovSmirnov2Sample.calculate_statistic(engine, ref, ref2)
 
     assert (

--- a/tests/integration/test_stats.py
+++ b/tests/integration/test_stats.py
@@ -1,0 +1,64 @@
+import pytest
+
+import datajudge
+from datajudge.db_access import DataReference, TableDataSource
+
+
+def test_cross_cdf_selection(engine, cross_cdf_table1, cross_cdf_table2):
+    database1, schema1, table1 = cross_cdf_table1
+    database2, schema2, table2 = cross_cdf_table2
+    tds1 = TableDataSource(database1, table1, schema1)
+    tds2 = TableDataSource(database2, table2, schema2)
+    ref1 = DataReference(tds1, columns=["col_int"])
+    ref2 = DataReference(tds2, columns=["col_int"])
+    selection, _, _ = datajudge.db_access._cross_cdf_selection(
+        engine, ref1, ref2, "cdf", "value"
+    )
+    with engine.connect() as connection:
+        result = connection.execute(selection).fetchall()
+    assert result is not None and len(result) > 0
+    expected_result = [
+        (1, 2 / 4, 0),
+        (2, 3 / 4, 0),
+        (3, 1, 1 / 5),
+        (4, 1, 2 / 5),
+        (5, 1, 4 / 5),
+        (8, 1, 1),
+    ]
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "configuration",
+    [  # these values were calculated using scipy.stats.ks_2samp on scipy=1.8.1
+        ("value_0_1", "value_0_1", 0.0, 1.0),
+        ("value_0_1", "value_005_1", 0.0294, 0.00035221594346540835),
+        ("value_0_1", "value_02_1", 0.0829, 2.6408848561586672e-30),
+        ("value_0_1", "value_1_1", 0.3924, 0.0),
+    ],
+)
+def test_ks_2sample_calculate_statistic(engine, random_normal_table, configuration):
+    col_1, col_2, expected_d, expected_p = configuration
+    database, schema, table = random_normal_table
+    tds = TableDataSource(database, table, schema)
+    ref = DataReference(tds, columns=[col_1])
+    ref2 = DataReference(tds, columns=[col_2])
+
+    (
+        d_statistic,
+        p_value,
+        n_samples,
+        m_samples,
+        _,
+    ) = datajudge.constraints.stats.KolmogorovSmirnov2Sample.calculate_statistic(
+        engine, ref, ref2
+    )
+
+    assert (
+        abs(d_statistic - expected_d) <= 1e-10
+    ), f"The test statistic does not match: {expected_d} vs {d_statistic}"
+
+    # 1e-05 should cover common p_values; if scipy is installed, a very accurate p_value is automatically calculated
+    assert (
+        abs(p_value - expected_p) <= 1e-05
+    ), f"The approx. p-value does not match: {expected_p} vs {p_value}"

--- a/tests/integration/test_stats.py
+++ b/tests/integration/test_stats.py
@@ -25,7 +25,7 @@ def test_cross_cdf_selection(engine, cross_cdf_table1, cross_cdf_table2):
         (5, 1, 4 / 5),
         (8, 1, 1),
     ]
-    assert result == expected_result
+    assert sorted(result) == expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See linked issues for context.

Importantly, I have high hopes that the isolation and explicit testing of `_cross_cdf_selection` will now be useful for other kinds of `Constraint`s, e.g. https://github.com/Quantco/datajudge/issues/45.