### PR TITLE
Publish on release

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
-        PYTHON_VERSION: ['3.8']
+      #matrix:
+      #  PYTHON_VERSION: ['3.8']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -16,7 +16,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
+          # python-version: ${{ matrix.PYTHON_VERSION }}
           miniforge-variant: Mambaforge
           miniforge-version: 4.11.0-2
           use-mamba: true
@@ -26,14 +26,14 @@ jobs:
       - name: Build
         shell: bash -l {0}
         # It seems as though flit publish expects a .pypirc file as compared to
-        # only a token passed as an argment.
+        # only a token passed as an argument.
         # See https://flit.pypa.io/en/latest/cmdline.html#flit-publish
         run: |
-          flit build --format sdist
+          flit build
 
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/*.tar.gz
+          path: dist/*
 
   upload_pypi:
     name: Upload to PyPI

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -5,10 +5,6 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -16,7 +12,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
+          python-version: 3.8
           miniforge-variant: Mambaforge
           miniforge-version: 4.11.0-2
           use-mamba: true

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -25,7 +25,9 @@ jobs:
           activate-environment: datajudge
 
       - name: Build
-        run: flit build --format sdist
+        shell: bash -l {0}
+        run: |
+          flit build --format sdist
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -5,6 +5,10 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        PYTHON_VERSION: ['3.8']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -12,7 +16,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.PYTHON_VERSION }}
           miniforge-variant: Mambaforge
           miniforge-version: 4.11.0-2
           use-mamba: true

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,10 +1,5 @@
 name: Build and upload to PyPI
-
-on:
-  pull_request:
-  release:
-    types:
-      - published
+on: [push]
 
 jobs:
   build_sdist:

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -15,6 +15,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.PYTHON_VERSION }}
+          miniforge-variant: Mambaforge
+          miniforge-version: 4.11.0-2
+          use-mamba: true
+          environment-file: environment.yml
+          activate-environment: datajudge
+
       - name: Build
         run: flit build --format sdist
 

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -2,13 +2,11 @@ name: Build and upload to PyPI
 on: [push]
 
 jobs:
-  build_sdist:
+  build_dist:
     name: Build source distribution
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      #matrix:
-      #  PYTHON_VERSION: ['3.8']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -16,7 +14,6 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          # python-version: ${{ matrix.PYTHON_VERSION }}
           miniforge-variant: Mambaforge
           miniforge-version: 4.11.0-2
           use-mamba: true
@@ -37,7 +34,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_sdist]
+    needs: [build_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -21,28 +21,15 @@ jobs:
 
       - name: Build
         shell: bash -l {0}
+        # It seems as though flit publish expects a .pypirc file as compared to
+        # only a token passed as an argment.
+        # See https://flit.pypa.io/en/latest/cmdline.html#flit-publish
         run: |
           flit build --format sdist
 
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
-
-  upload_testpypi:
-    name: Upload to TestPyPI
-    needs: [build_sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@v1.5.1
-        with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
 
   upload_pypi:
     name: Upload to PyPI

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
           miniforge-variant: Mambaforge
           miniforge-version: 4.11.0-2
           use-mamba: true

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,0 +1,55 @@
+name: Build and upload to PyPI
+
+on:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: flit build --format sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_testpypi:
+    name: Upload to TestPyPI
+    needs: [build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.TESTPYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [build_sdist, upload_testpypi]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -2,8 +2,8 @@ name: Build and upload to PyPI
 on: [push]
 
 jobs:
-  build_dist:
-    name: Build source distribution
+  build_artifacts:
+    name: Build artifacts
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -34,7 +34,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_dist]
+    needs: [build_artifacts]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -5,6 +5,10 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        PYTHON_VERSION: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -33,7 +37,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_sdist, upload_testpypi]
+    needs: [build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:


### PR DESCRIPTION
One advantage of shifting the deployment to github is that the secrets are collected in a central location, as opposed to locally held by the PyPI maintainers.


