### PR TITLE
add: infer primary columns from table definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+1.2.1 - 2022.11.??
+------------------
+
+**New features**
+- Implemented an option ``infer_pk`` to automatically retrieve and check primary key constraints as part of the `datajudge.WithinRequirement.add_uniqueness_constraint`.
+
+
 1.2.0 - 2022.10.21
 ------------------
 
@@ -15,7 +22,6 @@ Changelog
 - Implemented specification of number of counterexamples in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
 - Implemented in-database regex matching for some dialects via ``computation_in_db`` parameter in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
 - Added support for BigQuery backends.
-- Implemented an option ``infer_pk`` to automatically retrieve and check primary key constraints as part of the `datajudge.WithinRequirement.add_uniqueness_constraint`.
 
 **Bug fix:**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog
 
 - Implemented specification of number of counterexamples in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
 - Implemented in-database regex matching for some dialects via ``computation_in_db`` parameter in :meth:`~datajudge.WithinRequirement.add_varchar_regex_constraint`.
-
+- Implemented an option ``infer_pk`` to automatically retrieve and check primary key constraints as part of the `datajudge.WithinRequirement.add_uniqueness_constraint`.
 
 **Bug fix:**
 

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -53,7 +53,7 @@ class Uniqueness(Constraint):
         ref: DataReference,
         max_duplicate_fraction: float = 0,
         max_absolute_n_duplicates: int = 0,
-        infer_pk_columns=False
+        infer_pk_columns=False,
     ):
         if max_duplicate_fraction != 0 and max_absolute_n_duplicates != 0:
             raise ValueError(
@@ -72,10 +72,12 @@ class Uniqueness(Constraint):
         super().__init__(ref, ref_value=ref_value)
 
     def test(self, engine: sa.engine.Engine) -> TestResult:
-        
+
         # only check for primary keys when actually defined
         # otherwise default back to searching the whole table
-        if self.infer_pk_columns and (columns := db_access.get_primary_keys(engine, self.ref)[0]):
+        if self.infer_pk_columns and (
+            columns := db_access.get_primary_keys(engine, self.ref)[0]
+        ):
             self.ref.columns = columns
 
         unique_count, unique_selections = db_access.get_unique_count(engine, self.ref)

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -53,6 +53,7 @@ class Uniqueness(Constraint):
         ref: DataReference,
         max_duplicate_fraction: float = 0,
         max_absolute_n_duplicates: int = 0,
+        infer_pk_columns=False
     ):
         if max_duplicate_fraction != 0 and max_absolute_n_duplicates != 0:
             raise ValueError(
@@ -66,9 +67,17 @@ class Uniqueness(Constraint):
             ref_value = ("absolute", max_absolute_n_duplicates)
         else:
             ref_value = ("relative", 0)
+
+        self.infer_pk_columns = infer_pk_columns
         super().__init__(ref, ref_value=ref_value)
 
     def test(self, engine: sa.engine.Engine) -> TestResult:
+        
+        # only check for primary keys when actually defined
+        # otherwise default back to searching the whole table
+        if self.infer_pk_columns and (columns := db_access.get_primary_keys(engine, self.ref)[0]):
+            self.ref.columns = columns
+
         unique_count, unique_selections = db_access.get_unique_count(engine, self.ref)
         row_count, row_selections = db_access.get_row_count(engine, self.ref)
         self.factual_selections = row_selections

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -23,6 +23,7 @@ from .db_access import (
     RawQueryDataSource,
     TableDataSource,
     get_date_growth_rate,
+    get_primary_keys
 )
 
 T = TypeVar("T")
@@ -134,6 +135,7 @@ class WithinRequirement(Requirement):
         max_duplicate_fraction: float = 0,
         condition: Condition = None,
         max_absolute_n_duplicates: int = 0,
+        infer_pk_columns=False
     ):
         """Columns should uniquely identify row.
 
@@ -142,7 +144,8 @@ class WithinRequirement(Requirement):
         for inconsistencies, expressed via max_duplicate_fraction. The latter
         suggests that the number of uniques from said colums is larger or equal
         to (1 - max_duplicate_fraction) the number of rows.
-
+        
+        If infer_pk_columns is True, columns will be retrieved from the primary keys.
         """
         ref = DataReference(self.data_source, columns, condition)
         self._constraints.append(
@@ -150,6 +153,7 @@ class WithinRequirement(Requirement):
                 ref,
                 max_duplicate_fraction=max_duplicate_fraction,
                 max_absolute_n_duplicates=max_absolute_n_duplicates,
+                infer_pk_columns=infer_pk_columns
             )
         )
 

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -145,6 +145,8 @@ class WithinRequirement(Requirement):
         to (1 - max_duplicate_fraction) the number of rows.
 
         If infer_pk_columns is True, columns will be retrieved from the primary keys.
+        When columns=None and infer_pk_columns=False, the fallback is validating that all
+        rows in a table are unique.
         """
         ref = DataReference(self.data_source, columns, condition)
         self._constraints.append(

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -23,7 +23,6 @@ from .db_access import (
     RawQueryDataSource,
     TableDataSource,
     get_date_growth_rate,
-    get_primary_keys
 )
 
 T = TypeVar("T")
@@ -131,11 +130,11 @@ class WithinRequirement(Requirement):
 
     def add_uniqueness_constraint(
         self,
-        columns: List[str],
+        columns: List[str] = None,
         max_duplicate_fraction: float = 0,
         condition: Condition = None,
         max_absolute_n_duplicates: int = 0,
-        infer_pk_columns=False
+        infer_pk_columns=False,
     ):
         """Columns should uniquely identify row.
 
@@ -144,7 +143,7 @@ class WithinRequirement(Requirement):
         for inconsistencies, expressed via max_duplicate_fraction. The latter
         suggests that the number of uniques from said colums is larger or equal
         to (1 - max_duplicate_fraction) the number of rows.
-        
+
         If infer_pk_columns is True, columns will be retrieved from the primary keys.
         """
         ref = DataReference(self.data_source, columns, condition)
@@ -153,7 +152,7 @@ class WithinRequirement(Requirement):
                 ref,
                 max_duplicate_fraction=max_duplicate_fraction,
                 max_absolute_n_duplicates=max_absolute_n_duplicates,
-                infer_pk_columns=infer_pk_columns
+                infer_pk_columns=infer_pk_columns,
             )
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -131,6 +131,46 @@ def mix_table2(engine, metadata):
 
 
 @pytest.fixture(scope="module")
+def mix_table2_pk(engine, metadata):
+    table_name = "mix_table2_pk"
+    columns = [
+        sa.Column("col_int", sa.Integer(), primary_key=True),
+        sa.Column("col_varchar", sa.String()),
+        sa.Column("col_date", sa.DateTime()),
+    ]
+    data = [
+        {
+            "col_int": i,
+            "col_varchar": f"hi{i}",
+            "col_date": datetime.datetime(2016, 1, i // 2),
+        }
+        for i in range(2, 20)
+    ]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
+@pytest.fixture(scope="module")
+def mix_table2_pk_negate(engine, metadata):
+    table_name = "mix_table2_pk_negate"
+    columns = [
+        sa.Column("col_int", sa.Integer()),
+        sa.Column("col_varchar", sa.String()),
+        sa.Column("col_date", sa.DateTime(), primary_key=True),
+    ]
+    data = [
+        {
+            "col_int": i,
+            "col_varchar": f"hi{i}",
+            "col_date": datetime.datetime(2016, 1, i // 2),
+        }
+        for i in range(2, 20)
+    ]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
+@pytest.fixture(scope="module")
 def date_table1(engine, metadata):
     table_name = "date_table1"
     columns = [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -157,26 +157,6 @@ def mix_table2_pk(engine, metadata):
 
 
 @pytest.fixture(scope="module")
-def mix_table2_pk_negate(engine, metadata):
-    table_name = "mix_table2_pk_negate"
-    columns = [
-        sa.Column("col_int", sa.Integer()),
-        sa.Column("col_varchar", sa.String()),
-        sa.Column("col_date", sa.DateTime(), primary_key=True),
-    ]
-    data = [
-        {
-            "col_int": i,
-            "col_varchar": f"hi{i}",
-            "col_date": datetime.datetime(2016, 1, i // 2),
-        }
-        for i in range(2, 20)
-    ]
-    _handle_table(engine, metadata, table_name, columns, data)
-    return TEST_DB_NAME, SCHEMA, table_name
-
-
-@pytest.fixture(scope="module")
 def date_table1(engine, metadata):
     table_name = "date_table1"
     columns = [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1637,6 +1637,26 @@ def test_uniqueness_within(engine, mix_table2, data):
 
 @pytest.mark.parametrize(
     "data",
+    [
+        (identity, None, "mix_table2_pk"),
+        (identity, [], "mix_table2_pk"),
+        (identity, ["col_date"], "mix_table2_pk"),
+        (negation, None, "mix_table2_pk_negate"),
+    ],
+)
+def test_uniqueness_within_infer_pk(engine, data, request):
+    # We purposefully select a non-unique column ["col_date"] to validate
+    # that the reference columns are overwritten.
+    operation, columns, table_def = data
+    table = request.getfixturevalue(table_def)
+    req = requirements.WithinRequirement.from_table(*table)
+    req.add_uniqueness_constraint(columns=columns, infer_pk_columns=True)
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
+
+
+@pytest.mark.parametrize(
+    "data",
     [(identity, "int_table1", "col_int"), (negation, "unique_table1", "col_varchar")],
 )
 def test_null_absence_within(engine, get_fixture, data):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1652,18 +1652,16 @@ def test_uniqueness_within(engine, mix_table2, data):
 @pytest.mark.parametrize(
     "data",
     [
-        (identity, ["col_int"], None, "mix_table2_pk"),
-        (identity, ["col_int"], [], "mix_table2_pk"),
-        (identity, ["col_int"], ["col_date"], "mix_table2_pk"),
-        (negation, ["col_date"], None, "mix_table2_pk_negate"),
+        (identity, ["col_int"], None),
+        (identity, ["col_int"], []),
+        (identity, ["col_int"], ["col_date"]),
     ],
 )
-def test_uniqueness_within_infer_pk(engine, data, request):
+def test_uniqueness_within_infer_pk(engine, data, mix_table2_pk):
     # We purposefully select a non-unique column ["col_date"] to validate
     # that the reference columns are overwritten.
-    operation, target_columns, selection_columns, table_def = data
-    table = request.getfixturevalue(table_def)
-    req = requirements.WithinRequirement.from_table(*table)
+    operation, target_columns, selection_columns = data
+    req = requirements.WithinRequirement.from_table(*mix_table2_pk)
     req.add_uniqueness_constraint(columns=selection_columns, infer_pk_columns=True)
     test_result = req[0].test(engine)
     # additional test: the PK columns are inferred during test time, i.e. we can check here if they were inferred correctly


### PR DESCRIPTION
I am somewhat confused, thought the implementation was even easier but totally forgot that we have a clear seperation between test design time and test execution time (which I find really cool, btw).

Does anyone have an idea for a cleaner solution?