### PR TITLE
Run CI also on pull_request event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
This will lead to duplicate builds for people working inside the repository but I haven't found a better way yet.