### PR TITLE
Change build and publish trigger to also trigger for releases.

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,5 +1,14 @@
 name: Build and upload to PyPI
-on: [push]
+on:
+  pull request:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  release:
+    types:
+      - published
 
 jobs:
   build_artifacts:


### PR DESCRIPTION
Currently, the build-and-publish workflow is not triggered properly for releases, see here[0].

I find it difficult to test this change. Given that its' closer to what pytsql has[1], I'd be optimistic that it does the trick.

[0] https://github.com/Quantco/datajudge/actions/runs/3356293506
[1] https://github.com/Quantco/pytsql/blob/main/.github/workflows/build_and_publish.yml#L3-L7