### PR TITLE
Added the `typos` pre-commit hook and fixed a bunch of typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,8 @@ repos:
       - id: pyupgrade-conda
         args:
           - --py38-plus
+  - repo: https://github.com/Quantco/pre-commit-mirrors-typos
+    rev: 1.13.12
+    hooks:
+      - id: typos-conda
+        exclude: "\\.csv$"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+nd = "nd"

--- a/docs/source/examples/example.rst
+++ b/docs/source/examples/example.rst
@@ -132,7 +132,7 @@ As an example, we will run 4 tests on this table:
 
 
 Saving this file as ``specification.py`` and running ``$ pytest specification.py``
-will verify that all constaints are satisfied. The output you see in the terminal
+will verify that all constraints are satisfied. The output you see in the terminal
 should be similar to this:
 
 .. code-block::

--- a/docs/source/examples/example_exploration.rst
+++ b/docs/source/examples/example_exploration.rst
@@ -30,7 +30,7 @@ the hood. Importantly, ``Constraint`` s typically come with
 * a ``get_factual_value`` method: this is typically a wrapper around ``retrieve`` for the
   first ``DataReference`` of the given ``Requirement`` / ``Constraint``
 * a ``get_target_value`` method: this is either a wrapper around ``retrieve`` for the
-  second ``DataRefence`` in the case of a ``BetweenRequirement`` or an echoing of the
+  second ``DataReference`` in the case of a ``BetweenRequirement`` or an echoing of the
   ``Constraint`` s key reference value in the case of a ``WithinRequirement``
 
 Moreover, as is the case when using datajudge for testing purposes, these approaches rely

--- a/src/datajudge/constraints/uniques.py
+++ b/src/datajudge/constraints/uniques.py
@@ -38,7 +38,7 @@ class Uniques(Constraint, abc.ABC):
 
     The `Uniques` constraint asserts if the values contained in a column of a `DataSource`
     are part of a reference set of expected values - either externally supplied
-    through parameter `uniques` or obtained from another `DataSoure`.
+    through parameter `uniques` or obtained from another `DataSource`.
 
     Null values in the column are ignored. To assert the non-existence of them use
     the `NullAbsence` constraint via the `add_null_absence_constraint` helper method for

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -147,7 +147,7 @@ class WithinRequirement(Requirement):
         Given a set of columns, satisfy conditions of a primary key, i.e.
         uniqueness of tuples from said columns. This constraint has a tolerance
         for inconsistencies, expressed via max_duplicate_fraction. The latter
-        suggests that the number of uniques from said colums is larger or equal
+        suggests that the number of uniques from said columns is larger or equal
         to (1 - max_duplicate_fraction) the number of rows.
 
         If infer_pk_columns is True, columns will be retrieved from the primary keys.
@@ -663,7 +663,7 @@ class WithinRequirement(Requirement):
         n_counterexamples: int = 5,
     ):
         """
-        Assesses whether the values in a column match a given regular expresion pattern.
+        Assesses whether the values in a column match a given regular expression pattern.
 
         The option ``allow_none`` can be used in cases where the column is defined as
         nullable and contains null values.
@@ -705,7 +705,7 @@ class WithinRequirement(Requirement):
         n_counterexamples: int = 5,
     ):
         """
-        Assesses whether the values in a column match a given regular expresion pattern.
+        Assesses whether the values in a column match a given regular expression pattern.
 
         How the tolerance factor is calculated can be controlled with the ``aggregated``
         flag. When ``True``, the tolerance is calculated using unique values. If not, the
@@ -718,7 +718,7 @@ class WithinRequirement(Requirement):
         When using this method, the regex matching will take place in database, which is
         only supported for Postgres, Sqllite and Snowflake. Note that for this
         feature is only for Snowflake when using sqlalchemy-snowflake >= 1.4.0. As an
-        altenative, ``add_varchar_regex_constraint`` performs the regex matching in memory.
+        alternative, ``add_varchar_regex_constraint`` performs the regex matching in memory.
         This is typically slower and more expensive in terms of memory but available
         on all supported database mamangement systems.
         """
@@ -767,7 +767,7 @@ class WithinRequirement(Requirement):
         condition: Condition = None,
         name: str = None,
     ):
-        """Chek whether array aggregate corresponds to an integer range.
+        """Check whether array aggregate corresponds to an integer range.
 
         The ``DataSource`` is grouped by ``columns``. Sql's ``array_agg`` function is then
         applied to the ``aggregate_column``.
@@ -876,12 +876,12 @@ class BetweenRequirement(Requirement):
         date_column: Optional[str] = None,
         date_column2: Optional[str] = None,
     ):
-        """Create a ``BetwenTableRequirement`` based on sqlalchemy expressions.
+        """Create a ``BetweenTableRequirement`` based on sqlalchemy expressions.
 
         Any sqlalchemy object implementing the ``alias`` method can be passed as an
         argument for the ``expression1`` and ``expression2`` parameters. This could,
         e.g. be a ``sqlalchemy.Table`` object or the result of a ``sqlalchemy.select``
-        invokation.
+        invocation.
 
         ``name1`` and ``name2`` will be used to represent the expressions in error messages,
         respectively.
@@ -1386,7 +1386,7 @@ class BetweenRequirement(Requirement):
         Rows from T1 are indexed in columns1, rows from T2 are indexed in ``columns2``.
 
         In particular, the operation ``|T1-T2|`` relies on a sql ``EXCEPT`` statement. In
-        constrast to ``EXCEPT ALL``, this should lead to a set subtraction instead of
+        contrast to ``EXCEPT ALL``, this should lead to a set subtraction instead of
         a multiset subtraction. In other words, duplicates in T1 are treated as
         single occurrences.
         """

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1138,7 +1138,7 @@ def test_date_no_overlap_2d_within_several_key_columns(engine, date_table_keys, 
         # No overlap is no overlap
         (identity, 0, Condition(raw_string="id1 = 2"), True),
         (identity, 0, Condition(raw_string="id1 = 2"), False),
-        # Overlap on the treshold
+        # Overlap on the threshold
         (negation, 0, Condition(raw_string="id1 = 6"), True),
         (identity, 0, Condition(raw_string="id1 = 6"), False),
         # Overlap on more than the threshold
@@ -1397,7 +1397,7 @@ def test_varchar_regex_counterexample(
     else:
         assert location != -1
         # In the example of this very fixture, we know that no commas are used
-        # in values. We can therefore assume that commas indicate seperation
+        # in values. We can therefore assume that commas indicate separation
         # between counterexamples.
         assert (
             len(failure_message[location + len(marker) :].split(","))
@@ -1938,7 +1938,7 @@ def test_row_matching_equality(engine, row_match_table1, row_match_table2, data)
 @pytest.mark.parametrize("key", [("some_id",), ("some_id", "extra_id")])
 def test_groupby_aggregation_within(engine, groupby_aggregation_table_correct, key):
     skip_if_mssql(engine)
-    # TODO: This shoud actually work for db2
+    # TODO: This should actually work for db2
     if is_db2(engine):
         pytest.skip()
     if is_impala(engine):


### PR DESCRIPTION
I decided to run the typos [pre-commit hook](https://github.com/Quantco/pre-commit-mirrors-typos) on your repository. It found a lot of typos.