### PR TITLE
Implement a ``Constraint`` limiting the fraction of ``NULL`` values in a column.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@
 Changelog
 =========
 
+
+1.5.0 - 2022.03.XX
+------------------
+
+**New features**
+
+- Implement :meth:`datajudge.BetweenRequirement.add_max_null_fraction_constraint` and
+  :meth:`datajudge.WithinRequirement.add_max_null_fraction_constraint`.
+
+
 1.4.0 - 2022.02.24
 ------------------
 

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -133,21 +133,21 @@ class NullAbsence(Constraint):
         return TestResult(result, assertion_message)
 
 
-class MaxMissingFraction(Constraint):
+class MaxNullFraction(Constraint):
     def __init__(
         self,
         ref,
         *,
         ref2: DataReference = None,
-        max_missing_fraction: float = None,
+        max_null_fraction: float = None,
         max_relative_deviation: float = 0,
         name: str = None,
     ):
-        super().__init__(ref, ref2=ref2, ref_value=max_missing_fraction, name=name)
-        if max_missing_fraction is not None and not (0 <= max_missing_fraction <= 1):
+        super().__init__(ref, ref2=ref2, ref_value=max_null_fraction, name=name)
+        if max_null_fraction is not None and not (0 <= max_null_fraction <= 1):
             raise ValueError(
-                f"max_missing_fraction was expected to lie within [0, 1] but is "
-                f"{max_missing_fraction}."
+                f"max_null_fraction was expected to lie within [0, 1] but is "
+                f"{max_null_fraction}."
             )
         if max_relative_deviation < 0:
             raise ValueError(
@@ -164,7 +164,7 @@ class MaxMissingFraction(Constraint):
         threshold = missing_fracion_target * (1 + self.max_relative_deviation)
         result = missing_fraction_factual <= threshold
         assertion_text = (
-            f"{missing_fraction_factual} of {self.ref.get_string()} values are missing "
-            f"while only {self.target_prefix}{threshold} were allowed to be missing."
+            f"{missing_fraction_factual} of {self.ref.get_string()} values are NULL "
+            f"while only {self.target_prefix}{threshold} were allowed to be NULL."
         )
         return result, assertion_text

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -144,6 +144,15 @@ class MaxMissingFraction(Constraint):
         name: str = None,
     ):
         super().__init__(ref, ref2=ref2, ref_value=max_missing_fraction, name=name)
+        if max_missing_fraction is not None and not (0 <= max_missing_fraction <= 1):
+            raise ValueError(
+                f"max_missing_fraction was expected to lie within [0, 1] but is "
+                f"{max_missing_fraction}."
+            )
+        if max_relative_deviation < 0:
+            raise ValueError(
+                f"{max_relative_deviation} is negative even though it needs to be positive."
+            )
         self.max_relative_deviation = max_relative_deviation
 
     def retrieve(self, engine: sa.engine.Engine, ref: DataReference):

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -165,6 +165,6 @@ class MaxMissingFraction(Constraint):
         result = missing_fraction_factual <= threshold
         assertion_text = (
             f"{missing_fraction_factual} of {self.ref.get_string()} values are missing "
-            f"while only {threshold} where allowed to be missing."
+            f"while only {self.target_prefix}{threshold} were allowed to be missing."
         )
         return result, assertion_text

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -119,20 +119,6 @@ class Uniqueness(Constraint):
         return TestResult.failure(assertion_text)
 
 
-class NullAbsence(Constraint):
-    def __init__(self, ref: DataReference, name: str = None):
-        # This is arguably hacky. Passing this pointless string ensures that
-        # None-checks fail.
-        super().__init__(ref, ref_value="NoNull", name=name)
-
-    def test(self, engine: sa.engine) -> TestResult:
-        assertion_message = f"{self.ref.get_string()} contains NULLS."
-        query_result, selections = db_access.contains_null(engine, self.ref)
-        self.factual_selections = selections
-        result = not query_result
-        return TestResult(result, assertion_message)
-
-
 class MaxNullFraction(Constraint):
     def __init__(
         self,

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -856,18 +856,6 @@ def get_unique_count_union(engine, ref, ref2):
     return result, [selection]
 
 
-def contains_null(engine, ref):
-    selection = ref.get_selection(engine)
-    subquery = selection.distinct().alias()
-    selection = (
-        sa.select([sa.func.count()])
-        .select_from(subquery)
-        .where(subquery.c[ref.get_column(engine)].is_(None))
-    )
-    n_rows = engine.connect().execute(selection).scalar()
-    return n_rows > 0, [selection]
-
-
 def get_missing_fraction(engine, ref):
     selection = ref.get_selection(engine).subquery()
     n_rows_total_selection = sa.select([sa.func.count()]).select_from(selection)

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -177,7 +177,9 @@ class WithinRequirement(Requirement):
         self, column: str, condition: Condition = None, name: str = None
     ):
         ref = DataReference(self.data_source, [column], condition)
-        self._constraints.append(miscs_constraints.NullAbsence(ref, name=name))
+        self._constraints.append(
+            miscs_constraints.MaxNullFraction(ref, max_null_fraction=0, name=name)
+        )
 
     def add_max_null_fraction_constraint(
         self,

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -179,6 +179,21 @@ class WithinRequirement(Requirement):
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(miscs_constraints.NullAbsence(ref, name=name))
 
+    def add_max_missing_fraction_constraint(
+        self,
+        column: str,
+        max_missing_fraction: float,
+        condition: Condition = None,
+        name: str = None,
+    ):
+        """TODO"""
+        ref = DataReference(self.data_source, [column], condition)
+        self._constraints.append(
+            miscs_constraints.MaxMissingFraction(
+                ref, max_missing_fraction=max_missing_fraction, name=name
+            )
+        )
+
     def add_n_rows_equality_constraint(
         self, n_rows: int, condition: Condition = None, name: str = None
     ):
@@ -1065,6 +1080,26 @@ class BetweenRequirement(Requirement):
         self._constraints.append(
             uniques_constraints.NUniquesMaxLoss(
                 ref, ref2, max_relative_loss_getter, name=name
+            )
+        )
+
+    def add_max_missing_fraction_constraint(
+        self,
+        column1: str,
+        column2: str,
+        max_relative_deviation: float,
+        condition1: Condition = None,
+        condition2: Condition = None,
+        name: str = None,
+    ):
+        """TODO"""
+        ref = DataReference(self.data_source, [column1], condition1)
+        ref2 = DataReference(self.data_source2, [column2], condition2)
+        self._constraints.append(
+            miscs_constraints.MaxMissingFraction(
+                ref,
+                ref2=ref2,
+                max_relative_deviation=max_relative_deviation,
             )
         )
 

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -186,7 +186,10 @@ class WithinRequirement(Requirement):
         condition: Condition = None,
         name: str = None,
     ):
-        """TODO"""
+        """Assert that ``column`` has less than a certain fraction of ``NULL`` values.
+
+        ``max_missing_fraction`` is expected to be greater than 0.
+        """
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(
             miscs_constraints.MaxMissingFraction(
@@ -1092,7 +1095,12 @@ class BetweenRequirement(Requirement):
         condition2: Condition = None,
         name: str = None,
     ):
-        """TODO"""
+        """Assert that the fraction of ``NULL`` values of one is at most that of the other.
+
+        Given that ``column2``\'s underlying data has a fraction of missing data ``q``, the
+        ``max_relative_deviation`` parameter allows ``column1``\'s underlying data to have a
+        fraction of ``(1 + max_relative_deviation) * q`` to be missing.
+        """
         ref = DataReference(self.data_source, [column1], condition1)
         ref2 = DataReference(self.data_source2, [column2], condition2)
         self._constraints.append(

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -179,21 +179,21 @@ class WithinRequirement(Requirement):
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(miscs_constraints.NullAbsence(ref, name=name))
 
-    def add_max_missing_fraction_constraint(
+    def add_max_null_fraction_constraint(
         self,
         column: str,
-        max_missing_fraction: float,
+        max_null_fraction: float,
         condition: Condition = None,
         name: str = None,
     ):
         """Assert that ``column`` has less than a certain fraction of ``NULL`` values.
 
-        ``max_missing_fraction`` is expected to be greater than 0.
+        ``max_null_fraction`` is expected to be greater or equal than 0.
         """
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(
-            miscs_constraints.MaxMissingFraction(
-                ref, max_missing_fraction=max_missing_fraction, name=name
+            miscs_constraints.MaxNullFraction(
+                ref, max_null_fraction=max_null_fraction, name=name
             )
         )
 
@@ -1086,7 +1086,7 @@ class BetweenRequirement(Requirement):
             )
         )
 
-    def add_max_missing_fraction_constraint(
+    def add_max_null_fraction_constraint(
         self,
         column1: str,
         column2: str,
@@ -1097,14 +1097,14 @@ class BetweenRequirement(Requirement):
     ):
         """Assert that the fraction of ``NULL`` values of one is at most that of the other.
 
-        Given that ``column2``\'s underlying data has a fraction of missing data ``q``, the
+        Given that ``column2``\'s underlying data has a fraction ``q`` of ``NULL`` values, the
         ``max_relative_deviation`` parameter allows ``column1``\'s underlying data to have a
-        fraction of ``(1 + max_relative_deviation) * q`` to be missing.
+        fraction ``(1 + max_relative_deviation) * q`` of ``NULL`` values.
         """
         ref = DataReference(self.data_source, [column1], condition1)
         ref2 = DataReference(self.data_source2, [column2], condition2)
         self._constraints.append(
-            miscs_constraints.MaxMissingFraction(
+            miscs_constraints.MaxNullFraction(
                 ref,
                 ref2=ref2,
                 max_relative_deviation=max_relative_deviation,

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -190,7 +190,7 @@ class WithinRequirement(Requirement):
     ):
         """Assert that ``column`` has less than a certain fraction of ``NULL`` values.
 
-        ``max_null_fraction`` is expected to be greater or equal than 0.
+        ``max_null_fraction`` is expected to lie within [0, 1].
         """
         ref = DataReference(self.data_source, [column], condition)
         self._constraints.append(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1719,11 +1719,11 @@ def test_null_absence_within(engine, get_fixture, data):
         (negation, 2 / 63),
     ],
 )
-def test_max_missing_fraction_within(engine, unique_table1, data):
-    (operation, max_missing_fraction) = data
+def test_max_null_fraction_within(engine, unique_table1, data):
+    (operation, max_null_fraction) = data
     req = requirements.WithinRequirement.from_table(*unique_table1)
-    req.add_max_missing_fraction_constraint(
-        column="col_int", max_missing_fraction=max_missing_fraction
+    req.add_max_null_fraction_constraint(
+        column="col_int", max_null_fraction=max_null_fraction
     )
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
@@ -1738,13 +1738,13 @@ def test_max_missing_fraction_within(engine, unique_table1, data):
         (negation, "col_int", "col_varchar", 0.99),
     ],
 )
-def test_max_missing_fraction_between(engine, unique_table1, data):
+def test_max_null_fraction_between(engine, unique_table1, data):
     (operation, column1, column2, max_relative_deviation) = data
     req = requirements.BetweenRequirement.from_tables(
         *unique_table1,
         *unique_table1,
     )
-    req.add_max_missing_fraction_constraint(
+    req.add_max_null_fraction_constraint(
         column1=column1,
         column2=column2,
         max_relative_deviation=max_relative_deviation,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1715,6 +1715,47 @@ def test_null_absence_within(engine, get_fixture, data):
 @pytest.mark.parametrize(
     "data",
     [
+        (identity, 2 / 62),
+        (negation, 2 / 63),
+    ],
+)
+def test_max_missing_fraction_within(engine, unique_table1, data):
+    (operation, max_missing_fraction) = data
+    req = requirements.WithinRequirement.from_table(*unique_table1)
+    req.add_max_missing_fraction_constraint(
+        column="col_int", max_missing_fraction=max_missing_fraction
+    )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        (identity, "col_int", "col_int", 0),
+        (identity, "col_varchar", "col_int", 0),
+        (identity, "col_int", "col_varchar", 1),
+        (negation, "col_int", "col_varchar", 0.99),
+    ],
+)
+def test_max_missing_fraction_between(engine, unique_table1, data):
+    (operation, column1, column2, max_relative_deviation) = data
+    req = requirements.BetweenRequirement.from_tables(
+        *unique_table1,
+        *unique_table1,
+    )
+    req.add_max_missing_fraction_constraint(
+        column1=column1,
+        column2=column2,
+        max_relative_deviation=max_relative_deviation,
+    )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
         (identity, "col_varchar", "VARCHAR"),
         (identity, "col_int", "INTEGER"),
         (negation, "col_varchar", "INTEGER"),


### PR DESCRIPTION
In addition to introducing a ``Constraint`` limiting the fraction of NULL values in a column, this PR removes the pre-existing ``NullAbsence`` constraint since the latter is a special case of the former.

See https://github.com/Quantco/datajudge/pull/113/commits/c0348ee4a91007487f08a2078df57cc8dc46df69 for the removal of ``NullAbsence``.