### PR TITLE
extend interval constraints to work with integers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog
 
 - Implement :meth:`datajudge.WithinRequirement.add_value_distribution_constraint`.
 - Extended :meth:`datajudge.WithinRequirement.add_column_type_constraint` to support column type specification using string format, backend-specific SQLAlchemy types, and SQLAlchemy's generic types.
-
+- Implement :meth:`datajudge.WithinRequirement.add_numeric_no_gap_constraint`, :meth:`datajudge.WithinRequirement.add_numeric_no_overlap_constraint`,
 
 1.6.0 - 2022.04.12
 ------------------

--- a/src/datajudge/constraints/date.py
+++ b/src/datajudge/constraints/date.py
@@ -160,6 +160,19 @@ class DateBetween(Constraint):
 class DateNoOverlap(IntervalConstraint):
     _DIMENSIONS = 1
 
+    def __init__(
+        self,
+        ref: DataReference,
+        key_columns: Optional[List[str]],
+        start_columns: List[str],
+        end_columns: List[str],
+        max_relative_n_violations: float,
+        end_included: bool,
+        name: Optional[str] = None,
+    ):
+        self.end_included = end_included
+        super().__init__(ref, key_columns, start_columns, end_columns, max_relative_n_violations, name=name)
+
     def select(self, engine: sa.engine.Engine, ref: DataReference):
         sample_selection, n_violations_selection = db_access.get_date_overlaps_nd(
             engine,
@@ -190,6 +203,19 @@ class DateNoOverlap(IntervalConstraint):
 
 class DateNoOverlap2d(IntervalConstraint):
     _DIMENSIONS = 2
+
+    def __init__(
+        self,
+        ref: DataReference,
+        key_columns: Optional[List[str]],
+        start_columns: List[str],
+        end_columns: List[str],
+        max_relative_n_violations: float,
+        end_included: bool,
+        name: Optional[str] = None,
+    ):
+        self.end_included = end_included
+        super().__init__(ref, key_columns, start_columns, end_columns, max_relative_n_violations, name=name)
 
     def select(self, engine: sa.engine.Engine, ref: DataReference):
         sample_selection, n_violations_selection = db_access.get_date_overlaps_nd(
@@ -223,6 +249,19 @@ class DateNoOverlap2d(IntervalConstraint):
 class DateNoGap(IntervalConstraint):
     _DIMENSIONS = 1
 
+    def __init__(
+        self,
+        ref: DataReference,
+        key_columns: Optional[List[str]],
+        start_columns: List[str],
+        end_columns: List[str],
+        max_relative_n_violations: float,
+        legitimate_gap_size: bool,
+        name: Optional[str] = None,
+    ):
+        self.legitimate_gap_size = legitimate_gap_size
+        super().__init__(ref, key_columns, start_columns, end_columns, max_relative_n_violations, name=name)
+
     def select(self, engine: sa.engine.Engine, ref: DataReference):
         sample_selection, n_violations_selection = db_access.get_date_gaps(
             engine,
@@ -230,7 +269,7 @@ class DateNoGap(IntervalConstraint):
             self.key_columns,
             self.start_columns[0],
             self.end_columns[0],
-            self.end_included,
+            self.legitimate_gap_size,
         )
         # TODO: Once get_unique_count also only returns a selection without
         # executing it, one would want to list this selection here as well.

--- a/src/datajudge/constraints/date.py
+++ b/src/datajudge/constraints/date.py
@@ -171,10 +171,17 @@ class DateNoOverlap(IntervalConstraint):
         name: Optional[str] = None,
     ):
         self.end_included = end_included
-        super().__init__(ref, key_columns, start_columns, end_columns, max_relative_n_violations, name=name)
+        super().__init__(
+            ref,
+            key_columns,
+            start_columns,
+            end_columns,
+            max_relative_n_violations,
+            name=name,
+        )
 
     def select(self, engine: sa.engine.Engine, ref: DataReference):
-        sample_selection, n_violations_selection = db_access.get_date_overlaps_nd(
+        sample_selection, n_violations_selection = db_access.get_interval_overlaps_nd(
             engine,
             ref,
             self.key_columns,
@@ -215,10 +222,17 @@ class DateNoOverlap2d(IntervalConstraint):
         name: Optional[str] = None,
     ):
         self.end_included = end_included
-        super().__init__(ref, key_columns, start_columns, end_columns, max_relative_n_violations, name=name)
+        super().__init__(
+            ref,
+            key_columns,
+            start_columns,
+            end_columns,
+            max_relative_n_violations,
+            name=name,
+        )
 
     def select(self, engine: sa.engine.Engine, ref: DataReference):
-        sample_selection, n_violations_selection = db_access.get_date_overlaps_nd(
+        sample_selection, n_violations_selection = db_access.get_interval_overlaps_nd(
             engine,
             ref,
             self.key_columns,
@@ -256,11 +270,18 @@ class DateNoGap(IntervalConstraint):
         start_columns: List[str],
         end_columns: List[str],
         max_relative_n_violations: float,
-        legitimate_gap_size: bool,
+        legitimate_gap_size: float,
         name: Optional[str] = None,
     ):
         self.legitimate_gap_size = legitimate_gap_size
-        super().__init__(ref, key_columns, start_columns, end_columns, max_relative_n_violations, name=name)
+        super().__init__(
+            ref,
+            key_columns,
+            start_columns,
+            end_columns,
+            max_relative_n_violations,
+            name=name,
+        )
 
     def select(self, engine: sa.engine.Engine, ref: DataReference):
         sample_selection, n_violations_selection = db_access.get_date_gaps(

--- a/src/datajudge/constraints/interval.py
+++ b/src/datajudge/constraints/interval.py
@@ -8,7 +8,7 @@ from ..db_access import DataReference
 from .base import Constraint, OptionalSelections
 
 
-class IntervalConstraint(Constraint, abc.ABC):
+class IntervalConstraint(Constraint):
     _DIMENSIONS = 0
 
     def __init__(
@@ -62,7 +62,7 @@ class IntervalConstraint(Constraint, abc.ABC):
         return (n_violation_keys, n_distinct_key_values), selections
 
 
-class NoOverlapConstraint(IntervalConstraint, abc.ABC):
+class NoOverlapConstraint(IntervalConstraint):
     def __init__(
         self,
         ref: DataReference,
@@ -101,7 +101,7 @@ class NoOverlapConstraint(IntervalConstraint, abc.ABC):
         pass
 
 
-class NoGapConstraint(IntervalConstraint, abc.ABC):
+class NoGapConstraint(IntervalConstraint):
     def __init__(
         self,
         ref: DataReference,

--- a/src/datajudge/constraints/interval.py
+++ b/src/datajudge/constraints/interval.py
@@ -1,0 +1,93 @@
+import abc
+from typing import Any, List, Optional, Tuple
+from datajudge import db_access
+from datajudge.constraints.base import Constraint, OptionalSelections, TestResult
+from datajudge.db_access import DataReference
+import sqlalchemy as sa
+
+
+class IntervalConstraint(Constraint, abc.ABC):
+    _DIMENSIONS = 0
+
+    def __init__(
+        self,
+        ref: DataReference,
+        key_columns: Optional[List[str]],
+        start_columns: List[str],
+        end_columns: List[str],
+        end_included: bool,
+        max_relative_n_violations: float,
+        name: str = None,
+    ):
+        super().__init__(ref, ref_value=object(), name=name)
+        self.key_columns = key_columns
+        self.start_columns = start_columns
+        self.end_columns = end_columns
+        self.end_included = end_included
+        self.max_relative_n_violations = max_relative_n_violations
+        self._validate_dimensions()
+
+    @abc.abstractmethod
+    def select(self, engine: sa.engine.Engine, ref: DataReference):
+        pass
+
+    def _validate_dimensions(self):
+        if (length := len(self.start_columns)) != self._DIMENSIONS:
+            raise ValueError(
+                f"Expected {self._DIMENSIONS} start_column(s), got {length}."
+            )
+        if (length := len(self.end_columns)) != self._DIMENSIONS:
+            raise ValueError(
+                f"Expected {self._DIMENSIONS} end_column(s), got {length}."
+            )
+
+    def retrieve(
+        self, engine: sa.engine.Engine, ref: DataReference
+    ) -> Tuple[Tuple[int, int], OptionalSelections]:
+        keys_ref = DataReference(
+            data_source=self.ref.data_source,
+            columns=self.key_columns,
+            condition=self.ref.condition,
+        )
+        n_distinct_key_values, n_keys_selections = db_access.get_unique_count(
+            engine, keys_ref
+        )
+
+        sample_selection, n_violations_selection = self.select(engine, ref)
+        with engine.connect() as connection:
+            self.sample = connection.execute(sample_selection).first()
+            n_violation_keys = connection.execute(n_violations_selection).scalar()
+
+        selections = [*n_keys_selections, sample_selection, n_violations_selection]
+        return (n_violation_keys, n_distinct_key_values), selections
+    
+
+class IntegerNoGap(IntervalConstraint):
+    _DIMENSIONS = 1
+
+    def select(self, engine: sa.engine.Engine, ref: DataReference):
+        sample_selection, n_violations_selection = db_access.get_integer_gaps(
+            engine,
+            ref,
+            self.key_columns,
+            self.start_columns[0],
+            self.end_columns[0],
+            self.end_included,
+        )
+        # TODO: Once get_unique_count also only returns a selection without
+        # executing it, one would want to list this selection here as well.
+        return sample_selection, n_violations_selection
+
+    def compare(self, factual: Tuple[int, int], target: Any) -> Tuple[bool, str]:
+        n_violation_keys, n_distinct_key_values = factual
+        if n_distinct_key_values == 0:
+            return TestResult.success()
+        violation_fraction = n_violation_keys / n_distinct_key_values
+        assertion_text = (
+            f"{self.ref.get_string()} has a ratio of {violation_fraction} > "
+            f"{self.max_relative_n_violations} keys in columns {self.key_columns} "
+            f"with a gap in the range in {self.start_columns[0]} and {self.end_columns[0]}."
+            f"E.g. for: {self.sample}."
+        )
+        result = violation_fraction <= self.max_relative_n_violations
+        return result, assertion_text

--- a/src/datajudge/constraints/interval.py
+++ b/src/datajudge/constraints/interval.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 
 from .. import db_access
 from ..db_access import DataReference
-from .base import Constraint, OptionalSelections, TestResult
+from .base import Constraint, OptionalSelections
 
 
 class IntervalConstraint(Constraint, abc.ABC):
@@ -129,52 +129,3 @@ class NoGapConstraint(IntervalConstraint, abc.ABC):
     @abc.abstractmethod
     def compare(self, factual: Tuple[int, int], target: Any) -> Tuple[bool, str]:
         pass
-
-
-class NumericNoGap(NoGapConstraint):
-    _DIMENSIONS = 1
-
-    def select(self, engine: sa.engine.Engine, ref: DataReference):
-        sample_selection, n_violations_selection = db_access.get_numeric_gaps(
-            engine,
-            ref,
-            self.key_columns,
-            self.start_columns[0],
-            self.end_columns[0],
-            self.legitimate_gap_size,
-        )
-        # TODO: Once get_unique_count also only returns a selection without
-        # executing it, one would want to list this selection here as well.
-        return sample_selection, n_violations_selection
-
-    def compare(self, factual: Tuple[int, int], target: Any) -> Tuple[bool, str]:
-        n_violation_keys, n_distinct_key_values = factual
-        if n_distinct_key_values == 0:
-            return TestResult.success()
-        violation_fraction = n_violation_keys / n_distinct_key_values
-        assertion_text = (
-            f"{self.ref.get_string()} has a ratio of {violation_fraction} > "
-            f"{self.max_relative_n_violations} keys in columns {self.key_columns} "
-            f"with a gap in the range in {self.start_columns[0]} and {self.end_columns[0]}."
-            f"E.g. for: {self.sample}."
-        )
-        result = violation_fraction <= self.max_relative_n_violations
-        return result, assertion_text
-
-
-class NumericNoOverlap(NoOverlapConstraint):
-    _DIMENSIONS = 1
-
-    def compare(self, factual: Tuple[int, int], target: Any) -> Tuple[bool, str]:
-        n_violation_keys, n_distinct_key_values = factual
-        if n_distinct_key_values == 0:
-            return TestResult.success()
-        violation_fraction = n_violation_keys / n_distinct_key_values
-        assertion_text = (
-            f"{self.ref.get_string()} has a ratio of {violation_fraction} > "
-            f"{self.max_relative_n_violations} keys in columns {self.key_columns} "
-            f"with overlapping ranges in {self.start_columns[0]} and {self.end_columns[0]}."
-            f"E.g. for: {self.sample}."
-        )
-        result = violation_fraction <= self.max_relative_n_violations
-        return result, assertion_text

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -1,9 +1,7 @@
 import warnings
-from typing import Any, List, Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 import sqlalchemy as sa
-
-from .base import OptionalSelections
 
 from .. import db_access
 from ..db_access import DataReference

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -1,7 +1,10 @@
 import warnings
-from typing import List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 import sqlalchemy as sa
+
+from datajudge.constraints.base import OptionalSelections
+from datajudge.db_access import DataReference
 
 from .. import db_access
 from ..db_access import DataReference

--- a/src/datajudge/constraints/miscs.py
+++ b/src/datajudge/constraints/miscs.py
@@ -3,8 +3,7 @@ from typing import Any, List, Optional, Set, Tuple
 
 import sqlalchemy as sa
 
-from datajudge.constraints.base import OptionalSelections
-from datajudge.db_access import DataReference
+from .base import OptionalSelections
 
 from .. import db_access
 from ..db_access import DataReference

--- a/src/datajudge/constraints/numeric.py
+++ b/src/datajudge/constraints/numeric.py
@@ -1,10 +1,11 @@
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import sqlalchemy as sa
 
 from .. import db_access
 from ..db_access import DataReference
 from .base import Constraint, OptionalSelections, TestResult
+from .interval import NoGapConstraint, NoOverlapConstraint
 
 
 class NumericMin(Constraint):
@@ -236,3 +237,52 @@ class NumericPercentile(Constraint):
                 )
                 return False, assertion_message
         return True, None
+
+
+class NumericNoGap(NoGapConstraint):
+    _DIMENSIONS = 1
+
+    def select(self, engine: sa.engine.Engine, ref: DataReference):
+        sample_selection, n_violations_selection = db_access.get_numeric_gaps(
+            engine,
+            ref,
+            self.key_columns,
+            self.start_columns[0],
+            self.end_columns[0],
+            self.legitimate_gap_size,
+        )
+        # TODO: Once get_unique_count also only returns a selection without
+        # executing it, one would want to list this selection here as well.
+        return sample_selection, n_violations_selection
+
+    def compare(self, factual: Tuple[int, int], target: Any) -> Tuple[bool, str]:
+        n_violation_keys, n_distinct_key_values = factual
+        if n_distinct_key_values == 0:
+            return TestResult.success()
+        violation_fraction = n_violation_keys / n_distinct_key_values
+        assertion_text = (
+            f"{self.ref.get_string()} has a ratio of {violation_fraction} > "
+            f"{self.max_relative_n_violations} keys in columns {self.key_columns} "
+            f"with a gap in the range in {self.start_columns[0]} and {self.end_columns[0]}."
+            f"E.g. for: {self.sample}."
+        )
+        result = violation_fraction <= self.max_relative_n_violations
+        return result, assertion_text
+
+
+class NumericNoOverlap(NoOverlapConstraint):
+    _DIMENSIONS = 1
+
+    def compare(self, factual: Tuple[int, int], target: Any) -> Tuple[bool, str]:
+        n_violation_keys, n_distinct_key_values = factual
+        if n_distinct_key_values == 0:
+            return TestResult.success()
+        violation_fraction = n_violation_keys / n_distinct_key_values
+        assertion_text = (
+            f"{self.ref.get_string()} has a ratio of {violation_fraction} > "
+            f"{self.max_relative_n_violations} keys in columns {self.key_columns} "
+            f"with overlapping ranges in {self.start_columns[0]} and {self.end_columns[0]}."
+            f"E.g. for: {self.sample}."
+        )
+        result = violation_fraction <= self.max_relative_n_violations
+        return result, assertion_text

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -459,7 +459,7 @@ def get_date_growth_rate(engine, ref, ref2, date_column, date_column2):
     return date_span / date_span2 - 1, [*selections, *selections2]
 
 
-def get_date_overlaps_nd(
+def get_interval_overlaps_nd(
     engine: sa.engine.Engine,
     ref: DataReference,
     key_columns: list[str] | None,
@@ -669,6 +669,7 @@ def _get_interval_gaps(
 
     return violation_selection, n_violations_selection
 
+
 def _date_gap_condition(
     engine: sa.engine.Engine,
     start_table: sa.Subquery,
@@ -727,6 +728,8 @@ def _date_gap_condition(
     else:
         raise NotImplementedError(f"Date gaps not yet implemented for {engine.name}.")
     return gap_condition
+
+
 def get_date_gaps(
     engine: sa.engine.Engine,
     ref: DataReference,
@@ -745,6 +748,7 @@ def get_date_gaps(
         _date_gap_condition,
     )
 
+
 def _numeric_gap_condition(
     _engine: sa.engine.Engine,
     start_table: sa.Subquery,
@@ -754,9 +758,10 @@ def _numeric_gap_condition(
     legitimate_gap_size: float,
 ) -> sa.ColumnElement[bool]:
     gap_condition = (
-        (start_table.c[start_column] - end_table.c[end_column]) > legitimate_gap_size
-    )
+        start_table.c[start_column] - end_table.c[end_column]
+    ) > legitimate_gap_size
     return gap_condition
+
 
 def get_numeric_gaps(
     engine: sa.engine.Engine,

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -802,17 +802,17 @@ class WithinRequirement(Requirement):
                 start_columns=[start_column],
                 end_columns=[end_column],
                 max_relative_n_violations=max_relative_n_violations,
-                end_included=end_included,
+                legitimate_gap_size=1 if end_included else 0,
                 name=name,
             )
         )
 
-    def add_integer_no_gap_constraint(
+    def add_numeric_no_gap_constraint(
         self,
         start_column: str,
         end_column: str,
         key_columns: Optional[List[str]] = None,
-        end_included: bool = True,
+        legitimate_gap_size: float = 0,
         max_relative_n_violations: float = 0,
         condition: Condition = None,
         name: str = None,
@@ -822,13 +822,13 @@ class WithinRequirement(Requirement):
         )
         ref = DataReference(self.data_source, relevant_columns, condition)
         self._constraints.append(
-            interval_constraints.IntegerNoGap(
+            interval_constraints.NumericNoGap(
                 ref,
                 key_columns=key_columns,
                 start_columns=[start_column],
                 end_columns=[end_column],
+                legitimate_gap_size=legitimate_gap_size,
                 max_relative_n_violations=max_relative_n_violations,
-                end_included=end_included,
                 name=name,
             )
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -16,6 +16,7 @@ import sqlalchemy as sa
 
 from .constraints import column as column_constraints
 from .constraints import date as date_constraints
+from .constraints import interval as interval_constraints
 from .constraints import groupby as groupby_constraints
 from .constraints import miscs as miscs_constraints
 from .constraints import nrows as nrows_constraints
@@ -796,6 +797,32 @@ class WithinRequirement(Requirement):
         ref = DataReference(self.data_source, relevant_columns, condition)
         self._constraints.append(
             date_constraints.DateNoGap(
+                ref,
+                key_columns=key_columns,
+                start_columns=[start_column],
+                end_columns=[end_column],
+                max_relative_n_violations=max_relative_n_violations,
+                end_included=end_included,
+                name=name,
+            )
+        )
+
+    def add_integer_no_gap_constraint(
+        self,
+        start_column: str,
+        end_column: str,
+        key_columns: Optional[List[str]] = None,
+        end_included: bool = True,
+        max_relative_n_violations: float = 0,
+        condition: Condition = None,
+        name: str = None,
+    ):
+        relevant_columns = (
+            ([start_column, end_column] + key_columns) if key_columns else []
+        )
+        ref = DataReference(self.data_source, relevant_columns, condition)
+        self._constraints.append(
+            interval_constraints.IntegerNoGap(
                 ref,
                 key_columns=key_columns,
                 start_columns=[start_column],

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -16,8 +16,8 @@ import sqlalchemy as sa
 
 from .constraints import column as column_constraints
 from .constraints import date as date_constraints
-from .constraints import interval as interval_constraints
 from .constraints import groupby as groupby_constraints
+from .constraints import interval as interval_constraints
 from .constraints import miscs as miscs_constraints
 from .constraints import nrows as nrows_constraints
 from .constraints import numeric as numeric_constraints
@@ -858,6 +858,63 @@ class WithinRequirement(Requirement):
                 start_columns=[start_column],
                 end_columns=[end_column],
                 legitimate_gap_size=legitimate_gap_size,
+                max_relative_n_violations=max_relative_n_violations,
+                name=name,
+            )
+        )
+
+    def add_numeric_no_overlap_constraint(
+        self,
+        start_column: str,
+        end_column: str,
+        key_columns: Optional[List[str]] = None,
+        end_included: bool = True,
+        max_relative_n_violations: float = 0,
+        condition: Condition = None,
+        name: str = None,
+    ):
+        """Constraint expressing that several numeric interval rows may not overlap.
+
+        The ``DataSource`` under inspection must consist of at least one but up
+        to many ``key_columns``, identifying an entity, a ``start_column`` and an
+        ``end_column``.
+
+        For a given row in this ``DataSource``, ``start_column`` and ``end_column`` indicate a
+        numeric interval. Neither of those columns should contain NULL values. Also, it
+        should hold that for a given row, the value of ``end_column`` is strictly greater
+        than the value of ``start_column``.
+
+        Note that the value of ``start_column`` is expected to be included in each interval.
+        By default, the value of ``end_column`` is expected to be included as well -
+        this can however be changed by setting ``end_included`` to ``False``.
+
+        A 'key' is a fixed set of values in ``key_columns`` and represents an entity of
+        interest. A priori, a key is not a primary key, i.e., a key can have and often
+        has several rows. Thereby, a key will often come with several intervals.
+
+        Often, you might want the intervals for a given key not to overlap.
+
+        If ``key_columns`` is ``None`` or ``[]``, all columns of the table will be considered
+        as composing the key.
+
+        In order to express a tolerance for some violations of this non-overlapping
+        property, use the ``max_relative_n_violations`` parameter. The latter expresses for
+        what fraction of all key values, at least one overlap may exist.
+
+        For illustrative examples of this constraint, please refer to its test cases.
+        """
+
+        relevant_columns = [start_column, end_column] + (
+            key_columns if key_columns else []
+        )
+        ref = DataReference(self.data_source, relevant_columns, condition)
+        self._constraints.append(
+            interval_constraints.NumericNoOverlap(
+                ref,
+                key_columns=key_columns,
+                start_columns=[start_column],
+                end_columns=[end_column],
+                end_included=end_included,
                 max_relative_n_violations=max_relative_n_violations,
                 name=name,
             )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -817,6 +817,36 @@ class WithinRequirement(Requirement):
         condition: Condition = None,
         name: str = None,
     ):
+        """
+        Express that numeric interval rows have no gaps larger than some max value in-between them.
+        The table under inspection must consist of at least one but up to many key columns,
+        identifying an entity. Additionally, a ``start_column`` and an ``end_column``,
+        indicating interval start and end values, should be provided.
+
+        Neither of those columns should contain ``NULL`` values. Also, it should hold that
+        for a given row, the value of ``end_column`` is strictly greater than the value of
+        ``start_column``.
+
+
+        ``legitimate_gap_size`` is the maximum tollerated gap size between two intervals.
+
+        Note that the value of ``start_column`` is expected to be included in each interval.
+        By default, the value of ``end_column`` is expected to be included as well - this can
+        however be changed by setting ``end_included`` to ``False``.
+
+        A 'key' is a fixed set of values in ``key_columns`` and represents an entity of
+        interest. A priori, a key is not a primary key, i.e., a key can have and often has
+        several rows. Thereby, a key will often come with several intervals.
+
+        If`` key_columns`` is ``None`` or ``[]``, all columns of the table will be
+        considered as composing the key.
+
+        In order to express a tolerance for some violations of this gap property, use the
+        ``max_relative_n_violations`` parameter. The latter expresses for what fraction
+        of all key_values, at least one gap may exist.
+
+        For illustrative examples of this constraint, please refer to its test cases.
+        """
         relevant_columns = (
             ([start_column, end_column] + key_columns) if key_columns else []
         )

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -17,7 +17,6 @@ import sqlalchemy as sa
 from .constraints import column as column_constraints
 from .constraints import date as date_constraints
 from .constraints import groupby as groupby_constraints
-from .constraints import interval as interval_constraints
 from .constraints import miscs as miscs_constraints
 from .constraints import nrows as nrows_constraints
 from .constraints import numeric as numeric_constraints
@@ -847,7 +846,7 @@ class WithinRequirement(Requirement):
         )
         ref = DataReference(self.data_source, relevant_columns, condition)
         self._constraints.append(
-            interval_constraints.NumericNoGap(
+            numeric_constraints.NumericNoGap(
                 ref,
                 key_columns=key_columns,
                 start_columns=[start_column],
@@ -904,7 +903,7 @@ class WithinRequirement(Requirement):
         )
         ref = DataReference(self.data_source, relevant_columns, condition)
         self._constraints.append(
-            interval_constraints.NumericNoOverlap(
+            numeric_constraints.NumericNoOverlap(
                 ref,
                 key_columns=key_columns,
                 start_columns=[start_column],

--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -827,12 +827,7 @@ class WithinRequirement(Requirement):
         for a given row, the value of ``end_column`` is strictly greater than the value of
         ``start_column``.
 
-
         ``legitimate_gap_size`` is the maximum tollerated gap size between two intervals.
-
-        Note that the value of ``start_column`` is expected to be included in each interval.
-        By default, the value of ``end_column`` is expected to be included as well - this can
-        however be changed by setting ``end_included`` to ``False``.
 
         A 'key' is a fixed set of values in ``key_columns`` and represents an entity of
         interest. A priori, a key is not a primary key, i.e., a key can have and often has

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -384,6 +384,75 @@ def date_table_overlap_2d(engine, metadata):
 
 
 @pytest.fixture(scope="module")
+def integer_table_overlap(engine, metadata):
+    table_name = "integer_table_overlap"
+    columns = [
+        sa.Column("id1", sa.Integer()),
+        sa.Column("range_start", sa.Integer()),
+        sa.Column("range_end", sa.Integer()),
+    ]
+    data = []
+    # Trivial case: single entry.
+    data += [
+        {
+            "id1": 1,
+            "range_start": 1,
+            "range_end": 10,
+        }
+    ]
+    # 'Normal case': Multiple entries without overlap.
+    data += [
+        {
+            "id1": 2,
+            "range_start": i * 2,
+            "range_end": i * 2 + 1,
+        }
+        for i in range(1, 5)
+    ]
+    # Multiple entries with non-singleton overlap.
+    data += [
+        {
+            "id1": 3,
+            "range_start": 1,
+            "range_end": 10,
+        },
+        {
+            "id1": 3,
+            "range_start": 7,
+            "range_end": 15,
+        },
+    ]
+    # Multiple entries with singleton overlap.
+    data += [
+        {
+            "id1": 4,
+            "range_start": 1,
+            "range_end": 10,
+        },
+        {
+            "id1": 4,
+            "range_start": 10,
+            "range_end": 15,
+        },
+    ]
+    # Multiple entries with subset relation.
+    data += [
+        {
+            "id1": 5,
+            "range_start": 1,
+            "range_end": 10,
+        },
+        {
+            "id1": 5,
+            "range_start": 4,
+            "range_end": 8,
+        },
+    ]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
+
+@pytest.fixture(scope="module")
 def date_table_gap(engine, metadata):
     table_name = "date_table_gap"
     columns = [
@@ -451,6 +520,7 @@ def date_table_gap(engine, metadata):
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name
 
+
 @pytest.fixture(scope="module")
 def integer_table_gap(engine, metadata):
     table_name = "integer_table_gap"
@@ -506,13 +576,14 @@ def integer_table_gap(engine, metadata):
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name
 
+
 @pytest.fixture(scope="module")
 def float_table_gap(engine, metadata):
     table_name = "float_table_gap"
     columns = [
         sa.Column("id1", sa.Integer()),
-        sa.Column("range_start", sa.Integer()),
-        sa.Column("range_end", sa.Integer()),
+        sa.Column("range_start", sa.Float()),
+        sa.Column("range_end", sa.Float()),
     ]
     data = []
     # Single entry should not be considered a gap.
@@ -558,8 +629,22 @@ def float_table_gap(engine, metadata):
             "range_end": 10,
         },
     ]
+    # Multiple entries with tolerated gap.
+    data += [
+        {
+            "id1": 5,
+            "range_start": 1,
+            "range_end": 5,
+        },
+        {
+            "id1": 5,
+            "range_start": 5.5,
+            "range_end": 10,
+        },
+    ]
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name
+
 
 @pytest.fixture(scope="module")
 def date_table_keys(engine, metadata):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -451,6 +451,61 @@ def date_table_gap(engine, metadata):
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name
 
+@pytest.fixture(scope="module")
+def integer_table_gap(engine, metadata):
+    table_name = "integer_table_gap"
+    columns = [
+        sa.Column("id1", sa.Integer()),
+        sa.Column("range_start", sa.Integer()),
+        sa.Column("range_end", sa.Integer()),
+    ]
+    data = []
+    # Single entry should not be considered a gap.
+    data += [
+        {
+            "id1": 1,
+            "range_start": 1,
+            "range_end": 3,
+        }
+    ]
+    # Multiple entries without gap.
+    data += [
+        {
+            "id1": 2,
+            "range_start": 3 + i * 2,
+            "range_end": 5 + i * 2,
+        }
+        for i in range(1, 5)
+    ]
+    # Multiple entries with overlap.
+    data += [
+        {
+            "id1": 3,
+            "range_start": 1,
+            "range_end": 10,
+        },
+        {
+            "id1": 3,
+            "range_start": 3,
+            "range_end": 7,
+        },
+    ]
+    # Multiple entries with gap.
+    data += [
+        {
+            "id1": 4,
+            "range_start": 1,
+            "range_end": 5,
+        },
+        {
+            "id1": 4,
+            "range_start": 7,
+            "range_end": 10,
+        },
+    ]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
+
 
 @pytest.fixture(scope="module")
 def date_table_keys(engine, metadata):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -506,6 +506,60 @@ def integer_table_gap(engine, metadata):
     _handle_table(engine, metadata, table_name, columns, data)
     return TEST_DB_NAME, SCHEMA, table_name
 
+@pytest.fixture(scope="module")
+def float_table_gap(engine, metadata):
+    table_name = "float_table_gap"
+    columns = [
+        sa.Column("id1", sa.Integer()),
+        sa.Column("range_start", sa.Integer()),
+        sa.Column("range_end", sa.Integer()),
+    ]
+    data = []
+    # Single entry should not be considered a gap.
+    data += [
+        {
+            "id1": 1,
+            "range_start": 1,
+            "range_end": 3,
+        }
+    ]
+    # Multiple entries without gap.
+    data += [
+        {
+            "id1": 2,
+            "range_start": 3 + i * 2,
+            "range_end": 5 + i * 2,
+        }
+        for i in range(1, 5)
+    ]
+    # Multiple entries with overlap.
+    data += [
+        {
+            "id1": 3,
+            "range_start": 1,
+            "range_end": 10,
+        },
+        {
+            "id1": 3,
+            "range_start": 3,
+            "range_end": 7,
+        },
+    ]
+    # Multiple entries with gap.
+    data += [
+        {
+            "id1": 4,
+            "range_start": 1,
+            "range_end": 5,
+        },
+        {
+            "id1": 4,
+            "range_start": 8,
+            "range_end": 10,
+        },
+    ]
+    _handle_table(engine, metadata, table_name, columns, data)
+    return TEST_DB_NAME, SCHEMA, table_name
 
 @pytest.fixture(scope="module")
 def date_table_keys(engine, metadata):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1172,6 +1172,36 @@ def test_date_no_overlap_within_varying_key_columns(
 @pytest.mark.parametrize(
     "data",
     [
+        (identity, 0, Condition(raw_string="id1 = 1")),
+        (identity, 0, Condition(raw_string="id1 = 2")),
+        (negation, 0, Condition(raw_string="id1 = 3")),
+        (identity, 1, Condition(raw_string="id1 = 3")),
+        (negation, 0, Condition(raw_string="id1 = 4")),
+        (identity, 1, Condition(raw_string="id1 = 4")),
+        (negation, 0, Condition(raw_string="id1 = 5")),
+        (identity, 1, Condition(raw_string="id1 = 5")),
+    ],
+)
+@pytest.mark.parametrize("key_columns", [["id1"], [], None])
+def test_integer_no_overlap_within_varying_key_columns(
+    engine, integer_table_overlap, data, key_columns
+):
+    operation, max_relative_n_violations, condition = data
+    req = requirements.WithinRequirement.from_table(*integer_table_overlap)
+    req.add_numeric_no_overlap_constraint(
+        key_columns=key_columns,
+        start_column="range_start",
+        end_column="range_end",
+        max_relative_n_violations=max_relative_n_violations,
+        condition=condition,
+    )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
         (negation, 0.59, None),
         (identity, 0.6, None),
         (identity, 0, Condition(raw_string="id1 IN (1, 2)")),
@@ -1375,6 +1405,7 @@ def test_date_no_gap_within_fixed_key_columns(engine, date_table_gap, data):
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
 
+
 @pytest.mark.parametrize(
     "data",
     [
@@ -1398,6 +1429,7 @@ def test_integer_no_gap_within_fixed_key_columns(engine, integer_table_gap, data
     )
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
+
 
 @pytest.mark.parametrize(
     "data",
@@ -1423,6 +1455,7 @@ def test_float_no_gap_within_fixed_key_columns(engine, float_table_gap, data):
     )
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
+
 
 @pytest.mark.parametrize(
     "data",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1385,14 +1385,40 @@ def test_date_no_gap_within_fixed_key_columns(engine, date_table_gap, data):
         (identity, 0, None),
     ],
 )
-def test_integer_no_within_fixed_key_columns(engine, integer_table_gap, data):
+def test_integer_no_gap_within_fixed_key_columns(engine, integer_table_gap, data):
     operation, max_relative_n_violations, condition = data
     req = requirements.WithinRequirement.from_table(*integer_table_gap)
-    req.add_integer_no_gap_constraint(
+    req.add_numeric_no_gap_constraint(
         key_columns=["id1"],
         start_column="range_start",
         end_column="range_end",
         max_relative_n_violations=max_relative_n_violations,
+        legitimate_gap_size=0,
+        condition=condition,
+    )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        (identity, 0, Condition(raw_string="id1 = 1")),
+        (identity, 0, Condition(raw_string="id1 = 2")),
+        (identity, 0, Condition(raw_string="id1 = 3")),
+        (negation, 0, Condition(raw_string="id1 = 4")),
+        (negation, 0, Condition(raw_string="id1 = 5")),
+        (identity, 0.6, Condition(raw_string="id1 = 5")),
+    ],
+)
+def test_float_no_gap_within_fixed_key_columns(engine, float_table_gap, data):
+    operation, legitimate_gap_size, condition = data
+    req = requirements.WithinRequirement.from_table(*float_table_gap)
+    req.add_numeric_no_gap_constraint(
+        key_columns=["id1"],
+        start_column="range_start",
+        end_column="range_end",
+        legitimate_gap_size=legitimate_gap_size,
+        max_relative_n_violations=0,
         condition=condition,
     )
     test_result = req[0].test(engine)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1375,6 +1375,28 @@ def test_date_no_gap_within_fixed_key_columns(engine, date_table_gap, data):
     test_result = req[0].test(engine)
     assert operation(test_result.outcome), test_result.failure_message
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        (identity, 0, Condition(raw_string="id1 = 1")),
+        (identity, 0, Condition(raw_string="id1 = 2")),
+        (identity, 0, Condition(raw_string="id1 = 3")),
+        (negation, 0, Condition(raw_string="id1 = 4")),
+        (identity, 0, None),
+    ],
+)
+def test_integer_no_within_fixed_key_columns(engine, integer_table_gap, data):
+    operation, max_relative_n_violations, condition = data
+    req = requirements.WithinRequirement.from_table(*integer_table_gap)
+    req.add_integer_no_gap_constraint(
+        key_columns=["id1"],
+        start_column="range_start",
+        end_column="range_end",
+        max_relative_n_violations=max_relative_n_violations,
+        condition=condition,
+    )
+    test_result = req[0].test(engine)
+    assert operation(test_result.outcome), test_result.failure_message
 
 @pytest.mark.parametrize(
     "data",


### PR DESCRIPTION
Often one might want to check if non-date intervals have gaps or overlaps. This PR extends the existing functionality from supporting just dates to supporting numeric types in general. To allow the user to directly specify some tolerated gap sizes the `legitimate_gap_size` parameter is directly exposed. This allows for tolerating a gap of e.g 0.5 between [1, 5.5] and [6, 10] but rejecting a gap of [1, 5] [7, 10]