### PR TITLE
Provide better errors messages, if user passes a single column name instead of a list of columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       - id: isort-conda
         additional_dependencies: [-c, conda-forge, toml=0.10.2]
   - repo: https://github.com/Quantco/pre-commit-mirrors-mypy
-    rev: "1.2.0"
+    rev: "1.3.0"
     hooks:
       - id: mypy-conda
         additional_dependencies: [-c, conda-forge, types-setuptools]
   - repo: https://github.com/Quantco/pre-commit-mirrors-pyupgrade
-    rev: 3.3.2
+    rev: 3.4.0
     hooks:
       - id: pyupgrade-conda
         args:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+1.8.0 - 2023.XX.XX
+------------------
+
+**Other changes**
+
+- Improve error message when a :class:`~datajudge.DataReference` is constructed with a single column name instead of specifying a list of columns.
+
 1.7.0 - 2023.05.11
 ------------------
 

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -6,7 +6,7 @@ import operator
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
-from typing import Callable, Optional, Sequence, final, overload
+from typing import Callable, Sequence, final, overload
 
 import sqlalchemy as sa
 from sqlalchemy.sql import selectable
@@ -294,8 +294,8 @@ class DataReference:
     def __init__(
         self,
         data_source: DataSource,
-        columns: Optional[list[str]] = None,
-        condition: Optional[Condition] = None,
+        columns: list[str] | None = None,
+        condition: Condition | None = None,
     ):
         if columns is not None and not isinstance(columns, list):
             raise TypeError(f"columns must be a list, not {type(columns)}")

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -6,7 +6,7 @@ import operator
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
-from typing import Callable, Sequence, final, overload
+from typing import Callable, Optional, Sequence, final, overload
 
 import sqlalchemy as sa
 from sqlalchemy.sql import selectable
@@ -294,9 +294,12 @@ class DataReference:
     def __init__(
         self,
         data_source: DataSource,
-        columns: list[str] = None,
-        condition: Condition = None,
+        columns: Optional[list[str]] = None,
+        condition: Optional[Condition] = None,
     ):
+        if columns is not None and not isinstance(columns, list):
+            raise TypeError(f"columns must be a list, not {type(columns)}")
+
         self.data_source = data_source
         self.columns = columns
         self.condition = condition

--- a/tests/unit/test_pytest.py
+++ b/tests/unit/test_pytest.py
@@ -41,7 +41,7 @@ def test_test_name_within(method_name, arguments):
         ("add_varchar_min_length_constraint", ["column", "column"]),
         ("add_ks_2sample_constraint", ["column", "column"]),
         ("add_numeric_mean_constraint", ["column", "column", 0.1]),
-        ("add_row_superset_constraint", ["column", "column", 0]),
+        ("add_row_superset_constraint", [["column"], ["column"], 0]),
     ],
 )
 def test_test_name_between(method_name, arguments):


### PR DESCRIPTION
Currently, if a user specifies only one column name instead of a list of column names, the resulting error messages may occur late in execution and be opaque (see #152). This PR adds better error messages for this case.