### PR TITLE
Only use required columns in RowMatchingEquality

### DIFF
--- a/src/datajudge/requirements.py
+++ b/src/datajudge/requirements.py
@@ -1807,8 +1807,12 @@ class BetweenRequirement(Requirement):
         Alternatively, this can be thought of as counting mismatches in
         ``comparison_columns`` after performing an inner join on ``matching_columns``.
         """
-        ref = DataReference(self.data_source, None, condition1)
-        ref2 = DataReference(self.data_source2, None, condition2)
+        ref = DataReference(
+            self.data_source, matching_columns1 + comparison_columns1, condition1
+        )
+        ref2 = DataReference(
+            self.data_source2, matching_columns2 + comparison_columns2, condition2
+        )
         self._constraints.append(
             row_constraints.RowMatchingEquality(
                 ref,


### PR DESCRIPTION
I automatically generate documentation from my constraints, which contains, among other things, which columns are considered by a check. I noticed that `add_row_matching_equality_constraint` does not set a list of columns and therefore uses all of them. This selection can be restricted