### PR TITLE
Add formatting for assertion messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,13 @@
 Changelog
 =========
 
-1.8.0 - 2023.XX.XX
+1.9.0 - 2023.XX.XX
+------------------
+
+**New features**
+- Added styling for assertion messages. See :ref:`assertion-message-styling` for more information.
+
+1.8.0 - 2023.06.16
 ------------------
 
 **New features**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Changelog
 - Extended :meth:`datajudge.WithinRequirement.add_column_type_constraint` to support column type specification using string format, backend-specific SQLAlchemy types, and SQLAlchemy's generic types.
 - Implement :meth:`datajudge.WithinRequirement.add_numeric_no_gap_constraint`, :meth:`datajudge.WithinRequirement.add_numeric_no_overlap_constraint`,
 
-1.6.0 - 2022.04.12
+1.6.0 - 2023.04.12
 ------------------
 
 **Other changes**
@@ -35,7 +35,7 @@ Changelog
 - Ensure compatibility with ``sqlalchemy`` >= 2.0.
 
 
-1.5.0 - 2022.03.14
+1.5.0 - 2023.03.14
 ------------------
 
 **New features**
@@ -46,7 +46,7 @@ Changelog
   :meth:`datajudge.WithinRequirement.add_numeric_percentile_constraint`.
 
 
-1.4.0 - 2022.02.24
+1.4.0 - 2023.02.24
 ------------------
 
 **New features**
@@ -54,7 +54,7 @@ Changelog
 - Add partial and experimental support for db2 as a backend.
 
 
-1.3.0 - 2022.01.17
+1.3.0 - 2023.01.17
 ------------------
 
 **New features**

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -132,6 +132,27 @@ as well as the underlying database queries.
 Depending on the use case at hand, it might make sense to rely on this information for logging or data investigation
 purposes. Again, more on this in the article on :doc:`testing <testing>`.
 
+Assertion Message Styling
+----------------
+Constraints can use styling to increase the readability of their assertion messages.
+The styling can be set independently of the platform and converted to e.g. ANSI color codes for command line output or CSS color tags for HTML reports.
+The styling tags describe use cases and not concrete colors, so formatters can use arbitrary color palettes, and these are not fixed by the constraint.
+
+The following table lists all the supported codes, along with their descriptions and examples of how they can be used:
+
+
+.. list-table:: Supported styling codes
+   :header-rows: 1
+
+   * - Code
+     - Description
+     - Example
+   * - `numMatch`
+     - Indicates the part of a number that matches the expected value.
+     - `[numMatch]3.141[/numMatch]`
+   * - `numDifference`
+     - Indicates the part of a number that differs.
+     - `[numDifference]6[/numDifference]`
 
 Alternative DataSources
 ---------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - python>=3.8
   - pytest
   - pytest-cov
-  - conda-forge/label/pytest-html_rc::pytest-html==4.0.0rc4
   - pytest-xdist
   - make
   - numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python>=3.8
   - pytest
   - pytest-cov
-  - pytest-html
+  - conda-forge/label/pytest-html_rc::pytest-html==4.0.0rc4
   - pytest-xdist
   - make
   - numpydoc

--- a/src/datajudge/constraints/base.py
+++ b/src/datajudge/constraints/base.py
@@ -6,6 +6,9 @@ from typing import Any, Callable, List, Optional, Tuple, TypeVar
 import sqlalchemy as sa
 
 from ..db_access import DataReference
+from ..formatter import DefaultFormatter, Formatter
+
+DEFAULT_FORMATTER = DefaultFormatter()
 
 T = TypeVar("T")
 OptionalSelections = Optional[List[sa.sql.expression.Select]]
@@ -25,10 +28,30 @@ def uncommon_substrings(string1: str, string2: str) -> Tuple[str, str]:
 @dataclass(frozen=True)
 class TestResult:
     outcome: bool
-    failure_message: Optional[str] = field(default=None, repr=False)
-    constraint_description: Optional[str] = field(default=None, repr=False)
+    _failure_message: Optional[str] = field(default=None, repr=False)
+    _constraint_description: Optional[str] = field(default=None, repr=False)
     _factual_queries: Optional[str] = field(default=None, repr=False)
     _target_queries: Optional[str] = field(default=None, repr=False)
+
+    def formatted_failure_message(self, formatter: Formatter) -> Optional[str]:
+        return (
+            formatter.fmt_str(self._failure_message) if self._failure_message else None
+        )
+
+    def formatted_constraint_description(self, formatter: Formatter) -> Optional[str]:
+        return (
+            formatter.fmt_str(self._constraint_description)
+            if self._constraint_description
+            else None
+        )
+
+    @property
+    def failure_message(self) -> Optional[str]:
+        return self.formatted_failure_message(DEFAULT_FORMATTER)
+
+    @property
+    def constraint_description(self) -> Optional[str]:
+        return self.formatted_constraint_description(DEFAULT_FORMATTER)
 
     @property
     def logging_message(self):

--- a/src/datajudge/constraints/base.py
+++ b/src/datajudge/constraints/base.py
@@ -6,9 +6,9 @@ from typing import Any, Callable, List, Optional, Tuple, TypeVar
 import sqlalchemy as sa
 
 from ..db_access import DataReference
-from ..formatter import DefaultFormatter, Formatter
+from ..formatter import Formatter
 
-DEFAULT_FORMATTER = DefaultFormatter()
+DEFAULT_FORMATTER = Formatter()
 
 T = TypeVar("T")
 OptionalSelections = Optional[List[sa.sql.expression.Select]]

--- a/src/datajudge/formatter.py
+++ b/src/datajudge/formatter.py
@@ -1,0 +1,56 @@
+import abc
+import re
+
+from colorama import Fore, Style
+
+COLOR_REGEX = r"\[(red|green|yellow|blue|magenta|cyan|white|black)\](.*?)\[/\1\]"
+ALL_BB_REGEX = r"\[([a-zA-Z]*)\](.*)\[/\1\]"
+
+
+class Formatter(abc.ABC):
+    @abc.abstractmethod
+    def fmt_str(self, result: str) -> str:
+        pass
+
+
+class DefaultFormatter(Formatter):
+    def __init__(self):
+        self.bb_pattern = re.compile(ALL_BB_REGEX)
+
+    def strip_bb(self, string: str) -> str:
+        return self.bb_pattern.sub(lambda m: m.group(2), string)
+
+    def fmt_str(self, string: str) -> str:
+        return self.strip_bb(string)
+
+
+class AnsiColorFormatter(DefaultFormatter):
+    def __init__(self):
+        self.color_patterns = re.compile(COLOR_REGEX)
+        super().__init__()
+
+    def fmt_str(self, string: str) -> str:
+        # Replace bb color codes with colorama codes
+        string = self.color_patterns.sub(
+            lambda m: getattr(Fore, m.group(1).upper()) + m.group(2) + Style.RESET_ALL,
+            string,
+        )
+
+        # Stip all remaining bb code
+        return self.strip_bb(string)
+
+
+class HtmlFormatter(DefaultFormatter):
+    def __init__(self):
+        self.color_patterns = re.compile(COLOR_REGEX)
+        super().__init__()
+
+    def fmt_str(self, string: str) -> str:
+        # Replace bb color codes with html color tags
+        string = self.color_patterns.sub(
+            lambda m: f"<span style='color:{m.group(1)}'>{m.group(2)}</span>",
+            string,
+        )
+
+        # Stip all remaining bb code
+        return self.strip_bb(string)

--- a/src/datajudge/formatter.py
+++ b/src/datajudge/formatter.py
@@ -7,12 +7,6 @@ STYLING_CODES = r"\[(numMatch|numDiff)\](.*?)\[/\1\]"
 
 
 class Formatter(abc.ABC):
-    @abc.abstractmethod
-    def fmt_str(self, result: str) -> str:
-        pass
-
-
-class DefaultFormatter(Formatter):
     def __init__(self):
         self.known_bb_pattern = re.compile(STYLING_CODES)
 
@@ -29,7 +23,7 @@ class DefaultFormatter(Formatter):
         return string
 
 
-class AnsiColorFormatter(DefaultFormatter):
+class AnsiColorFormatter(Formatter):
     def apply_formatting(self, code: str, inner: str) -> str:
         if code == "numDiff":
             return f"{Back.CYAN}{inner}{Back.RESET}"
@@ -37,7 +31,7 @@ class AnsiColorFormatter(DefaultFormatter):
             return inner
 
 
-class HtmlFormatter(DefaultFormatter):
+class HtmlFormatter(Formatter):
     def apply_formatting(self, code: str, inner: str) -> str:
         if code == "numDiff":
             return f"<span style='background-color: #FF0000; color: #FFFFFF'>{inner}</span>"

--- a/src/datajudge/formatter.py
+++ b/src/datajudge/formatter.py
@@ -29,13 +29,3 @@ class AnsiColorFormatter(Formatter):
             return f"{Back.CYAN}{inner}{Back.RESET}"
         else:
             return inner
-
-
-class HtmlFormatter(Formatter):
-    def apply_formatting(self, code: str, inner: str) -> str:
-        if code == "numDiff":
-            return f"<span style='background-color: #FF0000; color: #FFFFFF'>{inner}</span>"
-        elif code == "numMatch":
-            return f"<span style='background-color: #00FF00; color: #FFFFFF'>{inner}</span>"
-        else:
-            return inner

--- a/src/datajudge/formatter.py
+++ b/src/datajudge/formatter.py
@@ -30,9 +30,6 @@ class DefaultFormatter(Formatter):
 
 
 class AnsiColorFormatter(DefaultFormatter):
-    def __init__(self):
-        super().__init__()
-
     def apply_formatting(self, code: str, inner: str) -> str:
         if code == "numDiff":
             return f"{Back.CYAN}{inner}{Back.RESET}"

--- a/src/datajudge/pytest_integration.py
+++ b/src/datajudge/pytest_integration.py
@@ -4,7 +4,21 @@ import pytest
 
 from .constraints.base import Constraint
 from .db_access import apply_patches
+from .formatter import AnsiColorFormatter, DefaultFormatter, HtmlFormatter
 from .requirements import Requirement
+
+
+@pytest.fixture(scope="session")
+def formatter(pytestconfig):
+    color = pytestconfig.getoption("color")
+    is_html = pytestconfig.getoption("htmlpath") is not None
+
+    if not is_html and (color == "yes" or color == "auto"):
+        return AnsiColorFormatter()
+    elif is_html and (color == "yes" or color == "auto"):
+        return HtmlFormatter()
+    else:
+        return DefaultFormatter()
 
 
 def collect_data_tests(requirements: Iterable[Requirement]):
@@ -21,10 +35,10 @@ def collect_data_tests(requirements: Iterable[Requirement]):
     @pytest.mark.parametrize(
         "constraint", all_constraints, ids=Constraint.get_description
     )
-    def test_constraint(constraint, datajudge_engine):
+    def test_constraint(constraint, datajudge_engine, formatter):
         # apply patches that fix sqlalchemy issues
         apply_patches(datajudge_engine)
         test_result = constraint.test(datajudge_engine)
-        assert test_result.outcome, test_result.failure_message
+        assert test_result.outcome, test_result.formatted_failure_message(formatter)
 
     return test_constraint

--- a/src/datajudge/pytest_integration.py
+++ b/src/datajudge/pytest_integration.py
@@ -4,7 +4,7 @@ import pytest
 
 from .constraints.base import Constraint
 from .db_access import apply_patches
-from .formatter import AnsiColorFormatter, DefaultFormatter, HtmlFormatter
+from .formatter import AnsiColorFormatter, Formatter, HtmlFormatter
 from .requirements import Requirement
 
 
@@ -18,7 +18,7 @@ def formatter(pytestconfig):
     elif is_html and (color == "yes" or color == "auto"):
         return HtmlFormatter()
     else:
-        return DefaultFormatter()
+        return Formatter()
 
 
 def collect_data_tests(requirements: Iterable[Requirement]):

--- a/src/datajudge/pytest_integration.py
+++ b/src/datajudge/pytest_integration.py
@@ -1,6 +1,7 @@
 from typing import Iterable
 
 import pytest
+from pkg_resources import parse_version
 
 from .constraints.base import Constraint
 from .db_access import apply_patches
@@ -12,6 +13,20 @@ def get_formatter(pytestconfig):
     color = pytestconfig.getoption("color")
 
     if color == "yes" or color == "auto":
+        # before pytest-html < 4.0.0
+        # styling in assertion messages was not formatted correctly
+        # so in this case we use the default formatter
+        # in pytest-html >= 4.0.0 the styling gets stripped or
+        # translated to ANSI codes, depending if ansi2html is installed
+        if pytestconfig.getoption("htmlpath", False):
+            try:
+                import pytest_html
+
+                if parse_version(pytest_html.__version__).major >= 4:
+                    return AnsiColorFormatter()
+            finally:
+                return Formatter()
+
         return AnsiColorFormatter()
     else:
         return Formatter()

--- a/tests/integration/pytest_testfile.py
+++ b/tests/integration/pytest_testfile.py
@@ -7,7 +7,7 @@ from datajudge.pytest_integration import collect_data_tests
 from datajudge.requirements import WithinRequirement
 
 example_req = WithinRequirement.from_table(
-    db_name=None, schema_name=None, table_name="companies"
+    db_name="main", schema_name="main", table_name="companies"
 )
 
 example_req.add_column_existence_constraint(columns=["name"])

--- a/tests/integration/pytest_testfile.py
+++ b/tests/integration/pytest_testfile.py
@@ -1,0 +1,42 @@
+import pytest
+import sqlalchemy as sa
+
+from datajudge.constraints.base import Constraint, TestResult
+from datajudge.db_access import DataReference
+from datajudge.pytest_integration import collect_data_tests
+from datajudge.requirements import WithinRequirement
+
+example_req = WithinRequirement.from_table(
+    db_name=None, schema_name=None, table_name="companies"
+)
+
+example_req.add_column_existence_constraint(columns=["name"])
+
+
+class StylizedTestConstraint(Constraint):
+    def test(self, engine: sa.engine.Engine) -> TestResult:
+        return TestResult.failure(
+            "This is a [numDiff]stylized[/numDiff] failure message"
+        )
+
+
+@pytest.fixture()
+def datajudge_engine():
+    eng = sa.create_engine("sqlite://")
+    eng.connect().execute(
+        sa.text(
+            "CREATE TABLE companies (id INTEGER PRIMARY KEY, name TEXT, num_employees INTEGER)"
+        )
+    )
+    return eng
+
+
+ref = DataReference(
+    data_source=example_req.data_source,
+    columns=["example"],
+    condition=None,
+)
+
+example_req.append(StylizedTestConstraint(ref, ref_value=object()))
+
+tests = collect_data_tests([example_req])

--- a/tests/integration/test_pytest_integration.py
+++ b/tests/integration/test_pytest_integration.py
@@ -1,0 +1,23 @@
+def test_formatter():
+    import os
+    import subprocess
+
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    output = subprocess.run(
+        ["pytest", "-s", "pytest_testfile.py", "--color", "yes"],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+    )
+    assert (
+        "AssertionError: This is a \x1b[46mstylized\x1b[49m failure message"
+        in output.stdout.decode("utf-8")
+    )
+
+    output = subprocess.run(
+        ["pytest", "-s", "pytest_testfile.py", "--color", "no"],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+    )
+    assert "AssertionError: This is a stylized failure message" in output.stdout.decode(
+        "utf-8"
+    )

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,6 +1,6 @@
 from colorama import Back
 
-from datajudge.formatter import AnsiColorFormatter, Formatter, HtmlFormatter
+from datajudge.formatter import AnsiColorFormatter, Formatter
 
 
 def test_default_formatter():
@@ -19,18 +19,5 @@ def test_ansi_color_formatter():
         formatter.fmt_str("[numDiff]Hello[/numDiff]") == f"{Back.CYAN}Hello{Back.RESET}"
     )
     assert formatter.fmt_str("[numMatch]Hello[/numMatch]") == "Hello"
-    assert formatter.fmt_str("[b]Hello[/b]") == "[b]Hello[/b]"
-    assert formatter.fmt_str("[numDiff]Hello[/numMatch]") == "[numDiff]Hello[/numMatch]"
-
-
-def test_html_formatter():
-    formatter = HtmlFormatter()
-
-    assert formatter.fmt_str("[numDiff]Hello[/numDiff]") == (
-        "<span style='background-color: #FF0000; color: #FFFFFF'>Hello</span>"
-    )
-    assert formatter.fmt_str("[numMatch]Hello[/numMatch]") == (
-        "<span style='background-color: #00FF00; color: #FFFFFF'>Hello</span>"
-    )
     assert formatter.fmt_str("[b]Hello[/b]") == "[b]Hello[/b]"
     assert formatter.fmt_str("[numDiff]Hello[/numMatch]") == "[numDiff]Hello[/numMatch]"

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,10 +1,10 @@
 from colorama import Back
 
-from datajudge.formatter import AnsiColorFormatter, DefaultFormatter, HtmlFormatter
+from datajudge.formatter import AnsiColorFormatter, Formatter, HtmlFormatter
 
 
 def test_default_formatter():
-    formatter = DefaultFormatter()
+    formatter = Formatter()
 
     assert formatter.fmt_str("[numDiff]Hello[/numDiff]") == "Hello"
     assert formatter.fmt_str("[numMatch]Hello[/numMatch]") == "Hello"

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,0 +1,36 @@
+from colorama import Fore, Style
+
+from datajudge.formatter import AnsiColorFormatter, DefaultFormatter, HtmlFormatter
+
+
+def test_default_formatter():
+    formatter = DefaultFormatter()
+
+    assert formatter.fmt_str("[b]Hello[/b]") == "Hello"
+    assert formatter.fmt_str("[red]Hello[/red]") == "Hello"
+    assert formatter.fmt_str("[red]Hello[/blue]") == "[red]Hello[/blue]"
+    assert formatter.fmt_str("[red]Hello[/red] [blue]World[/blue]") == "Hello World"
+    assert formatter.fmt_str("[]hello[/]") == "hello"
+
+
+def test_ansi_color_formatter():
+    formatter = AnsiColorFormatter()
+
+    # Test color formatting
+    assert formatter.fmt_str("[red]Hello[/red]") == f"{Fore.RED}Hello{Style.RESET_ALL}"
+    assert formatter.fmt_str("[red]Hello[/blue]") == "[red]Hello[/blue]"
+
+    # Test BB strip functionality
+    assert formatter.fmt_str("[invalid]Hello[/invalid]") == "Hello"
+
+
+def test_html_formatter():
+    formatter = HtmlFormatter()
+
+    assert (
+        formatter.fmt_str("[red]Hello[/red]") == "<span style='color:red'>Hello</span>"
+    )
+    assert formatter.fmt_str("[red]Hello[/blue]") == "[red]Hello[/blue]"
+
+    # Test BB strip functionality
+    assert formatter.fmt_str("[invalid]Hello[/invalid]") == "Hello"

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,4 +1,4 @@
-from colorama import Fore, Style
+from colorama import Back
 
 from datajudge.formatter import AnsiColorFormatter, DefaultFormatter, HtmlFormatter
 
@@ -6,31 +6,31 @@ from datajudge.formatter import AnsiColorFormatter, DefaultFormatter, HtmlFormat
 def test_default_formatter():
     formatter = DefaultFormatter()
 
-    assert formatter.fmt_str("[b]Hello[/b]") == "Hello"
-    assert formatter.fmt_str("[red]Hello[/red]") == "Hello"
-    assert formatter.fmt_str("[red]Hello[/blue]") == "[red]Hello[/blue]"
-    assert formatter.fmt_str("[red]Hello[/red] [blue]World[/blue]") == "Hello World"
-    assert formatter.fmt_str("[]hello[/]") == "hello"
+    assert formatter.fmt_str("[numDiff]Hello[/numDiff]") == "Hello"
+    assert formatter.fmt_str("[numMatch]Hello[/numMatch]") == "Hello"
+    assert formatter.fmt_str("[b]Hello[/b]") == "[b]Hello[/b]"
+    assert formatter.fmt_str("[numDiff]Hello[/numMatch]") == "[numDiff]Hello[/numMatch]"
 
 
 def test_ansi_color_formatter():
     formatter = AnsiColorFormatter()
 
-    # Test color formatting
-    assert formatter.fmt_str("[red]Hello[/red]") == f"{Fore.RED}Hello{Style.RESET_ALL}"
-    assert formatter.fmt_str("[red]Hello[/blue]") == "[red]Hello[/blue]"
-
-    # Test BB strip functionality
-    assert formatter.fmt_str("[invalid]Hello[/invalid]") == "Hello"
+    assert (
+        formatter.fmt_str("[numDiff]Hello[/numDiff]") == f"{Back.CYAN}Hello{Back.RESET}"
+    )
+    assert formatter.fmt_str("[numMatch]Hello[/numMatch]") == "Hello"
+    assert formatter.fmt_str("[b]Hello[/b]") == "[b]Hello[/b]"
+    assert formatter.fmt_str("[numDiff]Hello[/numMatch]") == "[numDiff]Hello[/numMatch]"
 
 
 def test_html_formatter():
     formatter = HtmlFormatter()
 
-    assert (
-        formatter.fmt_str("[red]Hello[/red]") == "<span style='color:red'>Hello</span>"
+    assert formatter.fmt_str("[numDiff]Hello[/numDiff]") == (
+        "<span style='background-color: #FF0000; color: #FFFFFF'>Hello</span>"
     )
-    assert formatter.fmt_str("[red]Hello[/blue]") == "[red]Hello[/blue]"
-
-    # Test BB strip functionality
-    assert formatter.fmt_str("[invalid]Hello[/invalid]") == "Hello"
+    assert formatter.fmt_str("[numMatch]Hello[/numMatch]") == (
+        "<span style='background-color: #00FF00; color: #FFFFFF'>Hello</span>"
+    )
+    assert formatter.fmt_str("[b]Hello[/b]") == "[b]Hello[/b]"
+    assert formatter.fmt_str("[numDiff]Hello[/numMatch]") == "[numDiff]Hello[/numMatch]"


### PR DESCRIPTION
This PR adds styling codes for assertion messages.
This allows constraints to use styling e.g. to increase readability of their assertion messages. The styling can then be set independently of the platform and converted to ANSI color codes for command line output, for example, and to CSS color tags for HTML reports. The styling tags describe use cases and not concrete colors, so formatter can use arbitrary color palettes and these are not fixed by the constraint. The first use-case which is supported is: numMatch and numDiff for (#89)


The assertion message can be formatted as follows: `[numMatch]3.141[/numMatch][numDifference]6[/numDifference] vs [numMatch]3.141[/numMatch][numDifference]5[/numDifference]`



 