### PR TITLE
Fix two minor errors in docs

### DIFF
--- a/docs/source/examples/example_dates.rst
+++ b/docs/source/examples/example_dates.rst
@@ -71,7 +71,7 @@ Assuming that such a table exists in database, we can write a specification agai
     prices_req.add_date_between_constraint(
         column="date_from",
 	lower_bound="'20220101'",
-	upper_bound="'20220101'",
+	upper_bound="'20220131'",
 	# We don't tolerate any violations of the constraint:
 	min_fraction=1,
     )
@@ -81,7 +81,7 @@ Assuming that such a table exists in database, we can write a specification agai
     prices_req.add_date_between_constraint(
         column="date_to",
 	lower_bound="'20220101'",
-	upper_bound="'20220101'",
+	upper_bound="'20220131'",
 	# We don't tolerate any violations of the constraint:
 	min_fraction=1,
     )


### PR DESCRIPTION
With this PR, I'd like to adjust the "Example: Dates" documentation.  The date ranges' upper bound should go until the end of January (`upper_bound="20220131"`), rather than the beginning of January (`upper_bound="20220101"`) to which it is set currently.