### PR TITLE
Fix warnings in building of documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,6 @@ extensions = [
     "numpydoc",
     "sphinxcontrib.apidoc",
     "sphinx.ext.autodoc",
-    "sphinx_autodoc_typehints",
 ]
 
 
@@ -32,4 +31,14 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 
-always_document_param_types = True
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "inherited-members": True,
+    "undoc-members": True,
+}
+autodoc_typehints = "description"
+
+# Copied from https://stackoverflow.com/questions/65198998/sphinx-warning-autosummary-stub-file-not-found-for-the-methods-of-the-class-c/
+# Also tested numpydoc_class_members_toctree = False but it does still create a TOC
+numpydoc_show_class_members = False

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -133,7 +133,7 @@ Depending on the use case at hand, it might make sense to rely on this informati
 purposes. Again, more on this in the article on :doc:`testing <testing>`.
 
 Assertion Message Styling
-----------------
+-------------------------
 Constraints can use styling to increase the readability of their assertion messages.
 The styling can be set independently of the platform and converted to e.g. ANSI color codes for command line output or CSS color tags for HTML reports.
 The styling tags describe use cases and not concrete colors, so formatters can use arbitrary color palettes, and these are not fixed by the constraint.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -21,7 +21,7 @@ one failing test to halt all others.
 
 Many of these approaches rely on adapting pytest's ``conftest.py``. If you are not familiar
 with this concept, you might want to read up on it
-`here <https://docs.pytest.org/en/6.2.x/writing_plugins.html#conftest-py-plugins>`_.
+`in the pytest docs <https://docs.pytest.org/en/6.2.x/writing_plugins.html#conftest-py-plugins>`_.
 
 Subselection
 ------------

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -97,21 +97,21 @@ def lowercase_column_names(column_names: str | list[str]) -> str | list[str]:
 class Condition:
     """Condition allows for further narrowing down of a DataSource in a Constraint.
 
-    A `Condition` can be thought of as a filter, the content of a sql 'where' clause
+    A ``Condition`` can be thought of as a filter, the content of a sql 'where' clause
     or a condition as known from probability theory.
 
-    While a `DataSource` is expressed more generally, one might be interested
-    in testing properties of a specific part of said `DataSource` in light
-    of a particular constraint. Hence using `Condition`s allows for the reusage
-    of a `DataSource, in lieu of creating a new custom `DataSource` with
-    the `Condition` implicitly built in.
+    While a ``DataSource`` is expressed more generally, one might be interested
+    in testing properties of a specific part of said ``DataSource`` in light
+    of a particular constraint. Hence using ``Condition`` allows for the reusage
+    of a ``DataSource``, in lieu of creating a new custom ``DataSource`` with
+    the ``Condition`` implicitly built in.
 
-    A `Condition` can either be 'atomic', i.e. not further reducible to sub-conditions
+    A ``Condition`` can either be 'atomic', i.e. not further reducible to sub-conditions
     or 'composite', i.e. combining multiple subconditions. In the former case, it can
-    be instantiated with help of the `raw_string` parameter, e.g. `"col1 > 0"`. In the
-    latter case, it can be instantiated with help of the `conditions` and
-    `reduction_operator` parameters. `reduction_operator` allows for two values: `"and"` (logical
-    conjunction) and `"or"` (logical disjunction). Note that composition of `Condition`s
+    be instantiated with help of the ``raw_string`` parameter, e.g. ``"col1 > 0"``. In the
+    latter case, it can be instantiated with help of the ``conditions`` and
+    ``reduction_operator`` parameters. ``reduction_operator`` allows for two values: ``"and"`` (logical
+    conjunction) and ``"or"`` (logical disjunction). Note that composition of ``Condition``
     supports arbitrary degrees of nesting.
     """
 


### PR DESCRIPTION
The rendered version of this PR can be found [here](https://datajudge--226.org.readthedocs.build/en/226/).

## Status quo

When running `make html` in `datajudge/docs` on `main`, 178 warnings are produced with `sphinx` 7.3.7.

Few of those warnings are indeed desired in that they hint at problems we'd want to fix, e.g. :

```
Assertion Message Styling
----------------
/Users/kevinklein/Code/datajudge/docs/source/getting_started.rst:136: WARNING: Title underline too short.

Assertion Message Styling
----------------
/Users/kevinklein/Code/datajudge/docs/source/testing.rst:2: WARNING: Duplicate explicit target name: "here".
```

Yet, the bulk of the warnings is of one of two forms:

* `/Users/kevinklein/Code/datajudge/src/datajudge/requirements.py:docstring of datajudge.requirements.Requirement:19: WARNING: autosummary: stub file not found 'datajudge.Requirement.append'. Check your autosummary_generate setting.`
* `/Users/kevinklein/Code/datajudge/src/datajudge/requirements.py:docstring of datajudge.requirements.Requirement.insert:21: WARNING: Explicit markup ends without a blank line; unexpected unindent.`

## Proposed changes

* Address the warnings we'd like to receive in [42f8a50](https://github.com/Quantco/datajudge/pull/226/commits/42f8a50faa54cdb62803c77af5c42979d4099ac8).
* Adapt the configuration of our documentation in [42f8a50](https://github.com/Quantco/datajudge/pull/226/commits/42f8a50faa54cdb62803c77af5c42979d4099ac8). 
  * The `autosummary: stub file not found 'datajudge.Requirement.append'. Check your autosummary_generate setting.` warnings are eliminated by inheriting doc strings for non-overwritten methods from parent classes.
  * The  `Explicit markup ends without a blank line; unexpected unindent.` warnings are eliminated for a reason that's clear to me.

Running `make html` on this branch creates no more warnings.

## Remarks

In order to address the `Explicit markup ends without a blank line; unexpected unindent.` warnings, I tried adaptations of the doc strings suggested in [this stackoverflow thread](https://stackoverflow.com/questions/38761546/markup-ending-without-empty-line-but-markup-is-only-thing-in-comment). Unfortunately it didn't resolve the issue at hand.
