### PR TITLE
Address mssql CI failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,10 +92,10 @@ jobs:
         with:
           environments: ${{ matrix.env }}
       # TODO: Consider removing this manual installation since the docker image already comes with a msodbc driver.
-      - name: Install msodbcsql17 driver
-        run: |
-          wget https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/m/msodbcsql17/msodbcsql17_17.9.1.1-1_amd64.deb
-          ACCEPT_EULA=Y sudo apt install ./msodbcsql17_17.9.1.1-1_amd64.deb --allow-downgrades
+      #- name: Install msodbcsql17 driver
+      #  run: |
+      #    wget https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/m/msodbcsql17/msodbcsql17_17.9.1.1-1_amd64.deb
+      #    ACCEPT_EULA=Y sudo apt install ./msodbcsql17_17.9.1.1-1_amd64.deb --allow-downgrades
       - name: Wait for SQL Server
         timeout-minutes: 1
         run: until docker logs "${{ job.services.db.id }}" 2>&1 | grep -q "SQL Server is now ready"; do sleep 10; done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,11 +91,6 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           environments: ${{ matrix.env }}
-      # TODO: Consider removing this manual installation since the docker image already comes with a msodbc driver.
-      #- name: Install msodbcsql17 driver
-      #  run: |
-      #    wget https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/m/msodbcsql17/msodbcsql17_17.9.1.1-1_amd64.deb
-      #    ACCEPT_EULA=Y sudo apt install ./msodbcsql17_17.9.1.1-1_amd64.deb --allow-downgrades
       - name: Wait for SQL Server
         timeout-minutes: 1
         run: until docker logs "${{ job.services.db.id }}" 2>&1 | grep -q "SQL Server is now ready"; do sleep 10; done

--- a/pixi.toml
+++ b/pixi.toml
@@ -45,7 +45,7 @@ freetds = "*"
 [feature.mssql.tasks]
 test = "pytest tests/integration --backend=mssql"
 test_freetds = "pytest tests/integration --backend=mssql-freetds"
-coverage = "pytest tests/integration --cov=datajudge --cov-report=xml --cov-append --backend=mssql"
+coverage = "pytest tests/integration --cov=datajudge --cov-report=xml --cov-append --backend=mssql-freetds"
 
 [feature.postgres.dependencies]
 psycopg2 = "*"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def get_engine(backend) -> sa.engine.Engine:
             connection_string += "?driver=libtdsodbc.so&tds_version=7.4"
         else:
             msodbc_driver_name = urllib.parse.quote_plus(
-                "ODBC Driver 17 for SQL Server"
+                "ODBC Driver 18 for SQL Server"
             )
             connection_string += f"?driver={msodbc_driver_name}"
     elif "snowflake" in backend:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def get_engine(backend) -> sa.engine.Engine:
             connection_string += "?driver=libtdsodbc.so&tds_version=7.4"
         else:
             msodbc_driver_name = urllib.parse.quote_plus(
-                "ODBC Driver 18 for SQL Server"
+                "ODBC Driver 17 for SQL Server"
             )
             connection_string += f"?driver={msodbc_driver_name}"
     elif "snowflake" in backend:


### PR DESCRIPTION
# Status quo

- Our mssql integration tests currentlhy support two drivers.
- Our CI integration tests only run tests against one of both.
- CI on main is failing for mssql

# Changes

This PR makes CI use the the other type of driver. While this doesn't solve the problem with the previous driver, it makes for a simpler set up and makes tests run through.

I'm very open to suggestions to go about this in a different way!