### PR TITLE
Address deprecation warnings from `sqlalchemy`

### DIFF
--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -602,8 +602,7 @@ def get_interval_overlaps_nd(
         *(
             # Already existing columns
             [
-                # TODO: Address deprecation warning
-                duplicate_selection.c[column]
+                duplicate_subquery.c[column]
                 for column in distinct_violation_subquery.columns.keys()
                 if column in duplicate_subquery.columns.keys()
             ]

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -988,8 +988,9 @@ def get_percentile(engine, ref, percentage):
         )
     )
 
+    # TODO: Address deprecation warning
     percentile_selection = sa.select(counting_subquery.c[column_name]).where(
-        counting_subquery.c[row_num] == argmin_selection
+        counting_subquery.c[row_num] == argmin_selection.scalar_subquery()
     )
     result = engine.connect().execute(percentile_selection).scalar()
     return result, [percentile_selection]

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -993,7 +993,6 @@ def get_percentile(engine, ref, percentage):
         )
     )
 
-    # TODO: Address deprecation warning
     percentile_selection = sa.select(counting_subquery.c[column_name]).where(
         counting_subquery.c[row_num] == argmin_selection.scalar_subquery()
     )

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -532,6 +532,7 @@ def get_interval_overlaps_nd(
 
     # Scenario 1
     duplicate_selection = duplicates(table1)
+    duplicate_subquery = duplicate_selection.subquery()
 
     # scenario 2
     naive_violation_condition = sa.and_(
@@ -577,6 +578,7 @@ def get_interval_overlaps_nd(
             for end_column in end_columns
         ],
     ).select_from(table1.join(table2, distinct_join_condition))
+    distinct_violation_subquery = distinct_violation_selection.subquery()
 
     # Note, Kevin, 21/12/09
     # The following approach would likely be preferable to the approach used
@@ -602,18 +604,14 @@ def get_interval_overlaps_nd(
             [
                 # TODO: Address deprecation warning
                 duplicate_selection.c[column]
-                # TODO: Address deprecation warning
-                for column in distinct_violation_selection.columns.keys()
-                # TODO: Address deprecation warning
-                if column in duplicate_selection.columns.keys()
+                for column in distinct_violation_subquery.columns.keys()
+                if column in duplicate_subquery.columns.keys()
             ]
             # Fill all missing columns with NULLs.
             + [
                 sa.null().label(column)
-                # TODO: Address deprecation warning
-                for column in distinct_violation_selection.columns.keys()
-                # TODO: Address deprecation warning
-                if column not in duplicate_selection.columns.keys()
+                for column in distinct_violation_subquery.columns.keys()
+                if column not in duplicate_subquery.columns.keys()
             ]
         )
     )

--- a/src/datajudge/db_access.py
+++ b/src/datajudge/db_access.py
@@ -600,14 +600,19 @@ def get_interval_overlaps_nd(
         *(
             # Already existing columns
             [
+                # TODO: Address deprecation warning
                 duplicate_selection.c[column]
+                # TODO: Address deprecation warning
                 for column in distinct_violation_selection.columns.keys()
+                # TODO: Address deprecation warning
                 if column in duplicate_selection.columns.keys()
             ]
             # Fill all missing columns with NULLs.
             + [
                 sa.null().label(column)
+                # TODO: Address deprecation warning
                 for column in distinct_violation_selection.columns.keys()
+                # TODO: Address deprecation warning
                 if column not in duplicate_selection.columns.keys()
             ]
         )


### PR DESCRIPTION
Our integration test suite produces thousands of `sqlalchemy` deprecation warnings caused by only six lines of code, see e.g. [this run on main](https://github.com/Quantco/datajudge/actions/runs/12984926252/job/36208770228). This PR addresses these deprecation warnings.